### PR TITLE
Add support for mongodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express-winston": "^3.1.0",
     "lodash": "^4.17.11",
     "merge": "^1.2.1",
+    "mongodb": "^3.2.7",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-bootstrap": "^1.0.0-beta.8",

--- a/src/common/config/env/all.js
+++ b/src/common/config/env/all.js
@@ -4,6 +4,9 @@ export default {
     https: {
       enabled: false,
     },
+    db: {
+      databaseName: 'boilerplate',
+    },
   },
   client: {},
 };

--- a/src/common/config/env/development.js
+++ b/src/common/config/env/development.js
@@ -1,31 +1,35 @@
 import merge from 'merge';
 import all from './all';
 
-export default merge.recursive(
-  all,
-  {
-    name: 'development',
-    server: {
-      log: {
-        level: 'silly',
-        transports: [{
+export default merge.recursive(all, {
+  name: 'development',
+  server: {
+    log: {
+      level: 'silly',
+      transports: [
+        {
           type: 'Console',
           options: {
             format: ['timestamp', 'colorize', 'simple'],
           },
-        }],
-      },
+        },
+      ],
     },
-    client: {
-      log: {
-        level: 'silly',
-        transports: [{
-          type: 'Console',
-          options: {
-            format: ['timestamp', 'colorize', 'simple'],
-          },
-        }],
-      },
+    db: {
+      connectionString: 'mongodb://localhost:27017',
     },
   },
-);
+  client: {
+    log: {
+      level: 'silly',
+      transports: [
+        {
+          type: 'Console',
+          options: {
+            format: ['timestamp', 'colorize', 'simple'],
+          },
+        },
+      ],
+    },
+  },
+});

--- a/src/common/config/env/production.js
+++ b/src/common/config/env/production.js
@@ -1,37 +1,41 @@
 import merge from 'merge';
 import all from './all';
 
-export default merge.recursive(
-  all,
-  {
-    name: 'production',
-    server: {
-      port: 443,
-      https: {
-        enabled: true,
-        // Figure out key management
-      },
-      log: {
-        level: 'warn',
-        transports: [{
+export default merge.recursive(all, {
+  name: 'production',
+  server: {
+    port: 443,
+    https: {
+      enabled: true,
+      // Figure out key management
+    },
+    log: {
+      level: 'warn',
+      transports: [
+        {
           type: 'File',
           options: {
             filename: '{LOG_ROOT}/{LOG_NAME}',
           },
-        }],
-      },
+        },
+      ],
     },
-    client: {
-      log: {
-        level: 'warn',
-        transports: [{
+    db: {
+      connectionString: 'mongodb://host.does.not.exist.yet:27017',
+    },
+  },
+  client: {
+    log: {
+      level: 'warn',
+      transports: [
+        {
           type: 'Http',
           options: {
             path: '/api/log',
             ssl: true,
           },
-        }],
-      },
+        },
+      ],
     },
   },
-);
+});

--- a/src/common/config/schema.js
+++ b/src/common/config/schema.js
@@ -9,6 +9,10 @@ const server = () => Joi.object({
     enabled: Joi.boolean().required(),
   }).required(),
   log: logSchema().required(),
+  db: Joi.object({
+    connectionString: Joi.string().required(),
+    databaseName: Joi.string().required(),
+  }).required(),
 });
 
 const client = () => Joi.object({

--- a/src/server/client/README
+++ b/src/server/client/README
@@ -1,0 +1,1 @@
+Libraries for interacting with external systems.

--- a/src/server/client/db-client.js
+++ b/src/server/client/db-client.js
@@ -1,0 +1,53 @@
+import { MongoClient } from 'mongodb';
+import config from '../../common/config';
+import { server as serverLogger } from '../../common/logger';
+
+class DbClient {
+  constructor() {
+    this.dbConfig = config().server.db;
+    this.logger = serverLogger('database');
+  }
+
+  /**
+   * Connect to the database and return a collection on the default database.
+   * @param {string} collectionName
+   *   The name of the collection on the database.
+   * @param {(collection:import('mongodb').Collection,db,dbClient)=>Promise<any>} callback
+   *   The method to call once the collection has been obtained.
+   */
+  async getCollection(collectionName, callback) {
+    this.logger.info(`getCollection('${collectionName}'): Called`);
+    const dbClient = new MongoClient(this.dbConfig.connectionString);
+    try {
+      this.logger.verbose(
+        `getCollection('${collectionName}'): Attempting to connect with connection string '${
+          this.dbConfig.connectionString
+        }'`,
+      );
+      await dbClient.connect();
+
+      this.logger.verbose(
+        `getCollection('${collectionName}'): Obtaining collection from '${
+          this.dbConfig.databaseName
+        }'`,
+      );
+      const db = dbClient.db(this.dbConfig.databaseName);
+      const collection = db.collection(collectionName);
+
+      this.logger.verbose(`getCollection('${collectionName}'): Performing database operation`);
+      const result = await callback(collection, db, dbClient);
+
+      this.logger.info(`getCollection('${collectionName}'): Complete`);
+      return result;
+    } catch (err) {
+      this.logger.error(`getCollection('${collectionName}'): Failed with error`);
+      this.logger.error(err);
+      throw err;
+    } finally {
+      this.logger.verbose(`getCollection('${collectionName}'): Closing connection`);
+      dbClient.close();
+    }
+  }
+}
+
+export default DbClient;

--- a/src/server/client/db-client.spec.js
+++ b/src/server/client/db-client.spec.js
@@ -1,0 +1,117 @@
+import { MongoClient } from 'mongodb';
+import config from '../../common/config';
+import { server as serverLogger } from '../../common/logger';
+import DbClient from './db-client';
+
+jest
+  .mock('mongodb')
+  .mock('../../common/config')
+  .mock('../../common/logger');
+
+describe('Database client', () => {
+  const dbConfig = {
+    connectionString: 'mongodb://mockserver:27017/',
+    databaseName: 'mockDb',
+  };
+  const logger = {
+    error: jest.fn(),
+    info: jest.fn(),
+    verbose: jest.fn(),
+  };
+  const mongoClient = {
+    connect: jest.fn(),
+    db: jest.fn(),
+    close: jest.fn(),
+  };
+  const mongoClientDb = {
+    collection: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    config.mockReturnValue({
+      server: {
+        db: dbConfig,
+      },
+    });
+    serverLogger.mockReturnValue(logger);
+    MongoClient.mockImplementation(() => mongoClient);
+    mongoClient.db.mockReturnValue(mongoClientDb);
+  });
+
+  describe('constructor', () => {
+    it('will retrieve configuration and get a logger', () => {
+      // Arrange
+      // Act
+      const dbClient = new DbClient();
+
+      // Assert
+      expect(config).toHaveBeenCalledTimes(1);
+      expect(config).toHaveBeenCalledWith();
+      expect(dbClient.dbConfig).toBe(dbConfig);
+
+      expect(serverLogger).toHaveBeenCalledTimes(1);
+      expect(serverLogger).toHaveBeenCalledWith('database');
+
+      expect(dbClient.logger).toBe(logger);
+    });
+  });
+
+  describe('getCollection', () => {
+    it('will log error when connect fails', async () => {
+      // Arrange
+      const err = new Error('Mock connection error');
+      mongoClient.connect.mockRejectedValue(err);
+      const callback = jest.fn();
+
+      // Act
+      const dbClient = new DbClient();
+      await expect(dbClient.getCollection('mockCollection', callback)).rejects.toThrow(
+        'Mock connection error',
+      );
+
+      // Assert
+      expect(callback).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledWith(err);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.verbose).toHaveBeenCalledTimes(2);
+    });
+
+    it('will log error when callback fails', async () => {
+      // Arrange
+      const err = new Error('Mock callback error');
+      mongoClient.connect.mockResolvedValue();
+      const callback = jest.fn().mockRejectedValue(err);
+
+      // Act
+      const dbClient = new DbClient();
+      await expect(dbClient.getCollection('mockCollection', callback)).rejects.toThrow(
+        'Mock callback error',
+      );
+
+      // Assert
+      expect(logger.error).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledWith(err);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.verbose).toHaveBeenCalledTimes(4);
+    });
+
+    it('will resolve with callback result', async () => {
+      // Arrange
+      const result = {};
+      mongoClient.connect.mockResolvedValue();
+      const callback = jest.fn().mockResolvedValue(result);
+
+      // Act
+      const dbClient = new DbClient();
+      const actualResult = await dbClient.getCollection('mockCollection', callback);
+
+      // Assert
+      expect(actualResult).toBe(result);
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledTimes(2);
+      expect(logger.verbose).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/server/paths/api/v0/character.js
+++ b/src/server/paths/api/v0/character.js
@@ -1,30 +1,21 @@
 import express from 'express';
 import jsonSerialize from 'serialize-javascript';
+import CharacterProxy from '../../../proxy/character-proxy';
 
 class Character {
   constructor() {
-    this.store = {
-      byId: {
-        a1: {
-          characterId: 'a1',
-          name: 'Armus',
-        },
-        b2: {
-          characterId: 'b2',
-          name: 'The Caretaker',
-        },
-      },
-      ids: ['a1', 'b2'],
-    };
+    this.proxy = new CharacterProxy();
   }
 
-  getCharacterIds = (_req, res) => {
-    res.type('application/json').send(jsonSerialize(this.store.ids));
+  getCharacterIds = async (_req, res) => {
+    const ids = await this.proxy.getCharacterIds();
+    res.type('application/json').send(jsonSerialize(ids));
   };
 
-  getCharacterById = (req, res) => {
+  getCharacterById = async (req, res) => {
     const { characterId } = req.params;
-    const character = this.store.byId[characterId];
+    const character = await this.proxy.getCharacterById(characterId);
+
     if (!character) {
       res
         .status(404)

--- a/src/server/paths/api/v0/character.node.spec.js
+++ b/src/server/paths/api/v0/character.node.spec.js
@@ -1,23 +1,25 @@
 import express from 'express';
 import jsonSerialize from 'serialize-javascript';
 import Character from './character';
+import MockCharacterProxy from '../../../proxy/character-proxy/mock-proxy';
 
 jest.mock('express');
 
 describe('Character router', () => {
   describe('getCharacterIds', () => {
-    it('will return the ids from the local store', () => {
+    it('will return the ids from the local store', async () => {
       // Arrange
       const ids = ['abc', 'def', '12345'];
       const router = new Character();
-      router.store.ids = ids;
+      router.proxy = new MockCharacterProxy();
+      router.proxy.store.ids = ids;
       const res = {
         type: jest.fn().mockReturnThis(),
         send: jest.fn(),
       };
 
       // Act
-      router.getCharacterIds({}, res);
+      await router.getCharacterIds({}, res);
 
       // Assert
       expect(res.type).toHaveBeenCalledWith('application/json');
@@ -26,11 +28,12 @@ describe('Character router', () => {
   });
 
   describe('getCharacterById', () => {
-    it('will return 404 if character id does not exist', () => {
+    it('will return 404 if character id does not exist', async () => {
       // Arrange
       const byId = {};
       const router = new Character();
-      router.store.byId = byId;
+      router.proxy = new MockCharacterProxy();
+      router.proxy.store.byId = byId;
       const req = {
         params: {
           characterId: 'abc',
@@ -43,7 +46,7 @@ describe('Character router', () => {
       };
 
       // Act
-      router.getCharacterById(req, res);
+      await router.getCharacterById(req, res);
 
       // Assert
       expect(res.status).toHaveBeenCalledWith(404);
@@ -51,13 +54,14 @@ describe('Character router', () => {
       expect(res.end).toHaveBeenCalledWith();
     });
 
-    it('will return the character if character exists', () => {
+    it('will return the character if character exists', async () => {
       // Arrange
       const byId = {
         abc: { characterId: 'abc', name: 'Foo' },
       };
       const router = new Character();
-      router.store.byId = byId;
+      router.proxy = new MockCharacterProxy();
+      router.proxy.store.byId = byId;
       const req = {
         params: {
           characterId: 'abc',
@@ -70,7 +74,7 @@ describe('Character router', () => {
       };
 
       // Act
-      router.getCharacterById(req, res);
+      await router.getCharacterById(req, res);
 
       // Assert
       expect(res.status).not.toHaveBeenCalled();

--- a/src/server/paths/root-router.node.spec.js
+++ b/src/server/paths/root-router.node.spec.js
@@ -1,12 +1,10 @@
 import express from 'express';
-import path from 'path';
 import RenderReact from './render-react';
 import ApiVersionRouter from './api/api-version-router';
 import RootRouter from './root-router';
 
 jest
   .mock('express')
-  .mock('path')
   .mock('./render-react')
   .mock('./api/api-version-router');
 
@@ -23,9 +21,6 @@ describe('RootRouter', () => {
   describe('initialize', () => {
     it('will set up the static route', () => {
       // Arrange
-      const staticRoot = '/dist/client';
-      path.join.mockReturnValue(staticRoot);
-
       const mockRouter = { use: jest.fn() };
       express.Router.mockReturnValue(mockRouter);
 
@@ -40,8 +35,7 @@ describe('RootRouter', () => {
       // Assert
       expect(result).toBe(mockRouter);
 
-      expect(path.join).toHaveBeenCalledWith(expect.any(String), '../../../dist/client/scripts');
-      expect(express.static).toHaveBeenCalledWith(staticRoot);
+      expect(express.static).toHaveBeenCalledWith(expect.any(String));
       expect(mockRouter.use).toHaveBeenCalledTimes(3);
       expect(mockRouter.use).toHaveBeenCalledWith('/', staticMiddleware);
       expect(mockRouter.use).toHaveBeenCalledWith('/', RenderReact.route);

--- a/src/server/proxy/character-proxy/index.js
+++ b/src/server/proxy/character-proxy/index.js
@@ -1,0 +1,23 @@
+import DbClient from '../../client/db-client';
+
+class CharacterProxy {
+  constructor() {
+    this.dbClient = new DbClient();
+  }
+
+  async getCharacterIds() {
+    return this.dbClient.getCollection('characters', collection =>
+      collection
+        .find({})
+        .project({ characterId: true })
+        .map(character => character.characterId)
+        .toArray());
+  }
+
+  async getCharacterById(characterId) {
+    return this.dbClient.getCollection('characters', collection =>
+      collection.findOne({ characterId }, { fields: { characterId: true, name: true } }));
+  }
+}
+
+export default CharacterProxy;

--- a/src/server/proxy/character-proxy/index.spec.js
+++ b/src/server/proxy/character-proxy/index.spec.js
@@ -1,0 +1,112 @@
+import DbClient from '../../client/db-client';
+import CharacterProxy from '.';
+
+jest.mock('../../client/db-client');
+
+describe('Character proxy', () => {
+  const mockDbClient = {
+    getCollection: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    DbClient.mockImplementation(() => mockDbClient);
+  });
+
+  describe('constructor', () => {
+    it('will instantiate the DbClient', () => {
+      // Arrange
+      // Act
+      const proxy = new CharacterProxy();
+
+      // Assert
+      expect(proxy).toBeDefined();
+      expect(DbClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getCharacterIds', () => {
+    it('will invoke getCollection when called', () => {
+      // Arrange
+      const proxy = new CharacterProxy();
+
+      // Act
+      proxy.getCharacterIds();
+
+      // Assert
+      expect(mockDbClient.getCollection).toHaveBeenCalledTimes(1);
+      expect(mockDbClient.getCollection).toHaveBeenCalledWith('characters', expect.any(Function));
+    });
+
+    it('will retrieve character IDs from the database', async () => {
+      // Arrange
+      const expectedResult = ['123', '456'];
+      const collection = {
+        find: jest.fn().mockReturnThis(),
+        project: jest.fn().mockReturnThis(),
+        map: jest.fn().mockReturnThis(),
+        toArray: jest.fn().mockResolvedValue(expectedResult),
+      };
+      const proxy = new CharacterProxy();
+      proxy.getCharacterIds();
+
+      const callback = mockDbClient.getCollection.mock.calls[0][1];
+
+      // Act
+      const result = await callback(collection);
+
+      // Assert
+      expect(result).toBe(expectedResult);
+      expect(collection.find).toHaveBeenCalledWith({});
+      expect(collection.project).toHaveBeenCalledWith({ characterId: true });
+      expect(collection.map).toHaveBeenCalledWith(expect.any(Function));
+      expect(collection.toArray).toHaveBeenCalledWith();
+
+      // Arrange
+      const mapCallback = collection.map.mock.calls[0][0];
+      const record = { characterId: 'foo' };
+
+      // Act
+      const mapResult = mapCallback(record);
+
+      // Assert
+      expect(mapResult).toEqual('foo');
+    });
+  });
+
+  describe('getCharacterById', () => {
+    it('will invoke getCollection when called', () => {
+      // Arrange
+      const proxy = new CharacterProxy();
+
+      // Act
+      proxy.getCharacterById('fooId');
+
+      // Assert
+      expect(mockDbClient.getCollection).toHaveBeenCalledTimes(1);
+      expect(mockDbClient.getCollection).toHaveBeenCalledWith('characters', expect.any(Function));
+    });
+
+    it('will retrieve a character from the database', async () => {
+      // Arrange
+      const expectedResult = { characterId: 'fooId' };
+      const collection = {
+        findOne: jest.fn().mockResolvedValue(expectedResult),
+      };
+      const proxy = new CharacterProxy();
+      proxy.getCharacterById('fooId');
+
+      const callback = mockDbClient.getCollection.mock.calls[0][1];
+
+      // Act
+      const result = await callback(collection);
+
+      // Assert
+      expect(result).toBe(expectedResult);
+      expect(collection.findOne).toHaveBeenCalledWith(
+        { characterId: 'fooId' },
+        { fields: { characterId: true, name: true } },
+      );
+    });
+  });
+});

--- a/src/server/proxy/character-proxy/mock-proxy.js
+++ b/src/server/proxy/character-proxy/mock-proxy.js
@@ -1,0 +1,27 @@
+class MockCharacterProxy {
+  constructor() {
+    this.store = {
+      byId: {
+        a1: {
+          characterId: 'a1',
+          name: 'Armus',
+        },
+        b2: {
+          characterId: 'b2',
+          name: 'The Caretaker',
+        },
+      },
+      ids: ['a1', 'b2'],
+    };
+  }
+
+  async getCharacterIds() {
+    return this.store.ids;
+  }
+
+  async getCharacterById(characterId) {
+    return this.store.byId[characterId];
+  }
+}
+
+export default MockCharacterProxy;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,6 +1816,11 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+bson@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.1.tgz#4330f5e99104c4e751e7351859e2d408279f2f13"
+  integrity sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==
+
 btoa@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.1.2.tgz#3e40b81663f81d2dd6596a4cb714a8dc16cfabe0"
@@ -5051,6 +5056,11 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -5204,6 +5214,25 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mongodb-core@3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.2.7.tgz#a8ef1fe764a192c979252dacbc600dc88d77e28f"
+  integrity sha512-WypKdLxFNPOH/Jy6i9z47IjG2wIldA54iDZBmHMINcgKOUcWJh8og+Wix76oGd7EyYkHJKssQ2FAOw5Su/n4XQ==
+  dependencies:
+    bson "^1.1.1"
+    require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongodb@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.2.7.tgz#8ba149e4be708257cad0dea72aebb2bbb311a7ac"
+  integrity sha512-2YdWrdf1PJgxcCrT1tWoL6nHuk6hCxhddAAaEh8QJL231ci4+P9FLyqopbTm2Z2sAU6mhCri+wd9r1hOcHdoMw==
+  dependencies:
+    mongodb-core "3.2.7"
+    safe-buffer "^5.1.2"
 
 moo@^0.4.3:
   version "0.4.3"
@@ -6640,6 +6669,14 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  integrity sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -6669,6 +6706,11 @@ resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   dependencies:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -6796,6 +6838,13 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+saslprep@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
+  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -6818,7 +6867,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
@@ -7031,6 +7080,13 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
+  dependencies:
+    memory-pager "^1.0.2"
 
 spdx-correct@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
By default, the dev environment looks for a MongoDB server on localhost
at port 27017. This will be modified later so that the dev environment
uses the mock proxy, and a new dev-live configuration will be created to
connect to a live DB.