### PR TITLE
GH-28: Redo character list as left-side pills

### DIFF
--- a/src/client/components/characters/character-list/__snapshots__/character-list.component.spec.js.snap
+++ b/src/client/components/characters/character-list/__snapshots__/character-list.component.spec.js.snap
@@ -6,31 +6,73 @@ exports[`CharacterList component will render Character components with the appro
   className="character-list"
   onSelect={[MockFunction]}
 >
-  <Tab
-    eventKey="a1a"
-    key="a1a"
-    title="Mock Character 1"
-  >
-    <ConnectFunction
-      characterId="a1a"
-      selected={false}
-    />
-  </Tab>
-  <Tab
-    eventKey="b2b"
-    key="b2b"
-    title="Mock Character 2"
-  >
-    <ConnectFunction
-      characterId="b2b"
-      selected={true}
-    />
-  </Tab>
-  <Tab
-    eventKey=""
-    title={<MdAdd />}
-  >
-    <ConnectFunction />
-  </Tab>
+  <Bootstrap(Row)>
+    <Col
+      as="div"
+      sm={3}
+    >
+      <Nav
+        as="div"
+        className="flex-column"
+        fill={false}
+        justify={false}
+        variant="pills"
+      >
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="a1a"
+          key="a1a"
+        >
+          Mock Character 1
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="b2b"
+          key="b2b"
+        >
+          Mock Character 2
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey=""
+        >
+          <MdAdd />
+        </NavLink>
+      </Nav>
+    </Col>
+    <Col
+      as="div"
+      sm={9}
+    >
+      <Bootstrap(TabContent)>
+        <TabPane
+          eventKey="a1a"
+          key="a1a"
+        >
+          <ConnectFunction
+            characterId="a1a"
+            selected={false}
+          />
+        </TabPane>
+        <TabPane
+          eventKey="b2b"
+          key="b2b"
+        >
+          <ConnectFunction
+            characterId="b2b"
+            selected={true}
+          />
+        </TabPane>
+        <TabPane
+          eventKey=""
+        >
+          <ConnectFunction />
+        </TabPane>
+      </Bootstrap(TabContent)>
+    </Col>
+  </Bootstrap(Row)>
 </ForwardRef>
 `;

--- a/src/client/components/characters/character-list/character-list.component.js
+++ b/src/client/components/characters/character-list/character-list.component.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Tabs, Tab } from 'react-bootstrap';
+import {
+  Tab, Row, Col, Nav,
+} from 'react-bootstrap';
 import { MdAdd } from 'react-icons/md';
 import Character from '../character';
 import NewCharacter from '../new-character';
@@ -8,16 +10,34 @@ import NewCharacter from '../new-character';
 const CharacterList = ({
   characterIds, characterNames, selectedId, setSelected,
 }) => (
-  <Tabs className="character-list" activeKey={selectedId} onSelect={setSelected}>
-    {characterIds.map(id => (
-      <Tab key={id} eventKey={id} title={characterNames[id]}>
-        <Character characterId={id} selected={id === selectedId} />
-      </Tab>
-    ))}
-    <Tab title={<MdAdd />} eventKey="">
-      <NewCharacter />
-    </Tab>
-  </Tabs>
+  <Tab.Container className="character-list" activeKey={selectedId} onSelect={setSelected}>
+    <Row>
+      <Col sm={3}>
+        <Nav variant="pills" className="flex-column">
+          {characterIds.map(id => (
+            <Nav.Link key={id} eventKey={id}>
+              {characterNames[id]}
+            </Nav.Link>
+          ))}
+          <Nav.Link eventKey="">
+            <MdAdd />
+          </Nav.Link>
+        </Nav>
+      </Col>
+      <Col sm={9}>
+        <Tab.Content>
+          {characterIds.map(id => (
+            <Tab.Pane key={id} eventKey={id}>
+              <Character characterId={id} selected={id === selectedId} />
+            </Tab.Pane>
+          ))}
+          <Tab.Pane eventKey="">
+            <NewCharacter />
+          </Tab.Pane>
+        </Tab.Content>
+      </Col>
+    </Row>
+  </Tab.Container>
 );
 
 CharacterList.propTypes = {


### PR DESCRIPTION
Use custom tab layout based on a column of character name buttons to
select the desired character tab.

This is in preparation for retrieving character IDs from the API and
being able to dynamically grow the character name column/retrieve from
the database in pages rather than all at once.