### PR TITLE
GH-28: Support limit and cursor parameters on character list

### DIFF
--- a/src/server/proxy/character-proxy/index.js
+++ b/src/server/proxy/character-proxy/index.js
@@ -5,15 +5,54 @@ class CharacterProxy {
     this.dbClient = new DbClient();
   }
 
-  async getCharacterIds() {
-    return this.dbClient.getDatabase(db =>
-      db
+  static getQueryFromCursor(cursor) {
+    // 'cursor' is base64-encoded LE 48-bit value representing milliseconds
+    return cursor
+      ? {
+        createdDate: { $gte: new Date(Buffer.from(cursor, 'base64').readIntLE(0, 6)) },
+      }
+      : {};
+  }
+
+  static getCursorFromElement(element) {
+    if (!element) {
+      return null;
+    }
+    const { createdDate } = element;
+    if (!createdDate) {
+      return null;
+    }
+
+    const buffer = Buffer.alloc(6);
+    buffer.writeIntLE(createdDate.getTime(), 0, 6);
+    return buffer.toString('base64');
+  }
+
+  async getCharacterIds(limit, cursor) {
+    return this.dbClient.getDatabase(async (db) => {
+      const query = CharacterProxy.getQueryFromCursor(cursor);
+      const results = db
         .collection('characters')
-        .find({})
+        .find(query)
         .hint('dateIdName')
         .sort({ createdDate: 1 })
-        .project({ characterId: true, name: true, _id: false })
-        .toArray());
+        .project({
+          characterId: true,
+          name: true,
+          createdDate: true,
+          _id: false,
+        })
+        .limit(limit + 1);
+      const characters = await results.toArray();
+      const nextCharacter = characters.length > limit && characters.pop();
+      return {
+        items: characters.map(({ characterId, name }) => ({
+          id: characterId,
+          name,
+        })),
+        nextCursor: CharacterProxy.getCursorFromElement(nextCharacter),
+      };
+    });
   }
 
   async getCharacterById(characterId) {

--- a/src/server/proxy/character-proxy/index.spec.js
+++ b/src/server/proxy/character-proxy/index.spec.js
@@ -25,7 +25,86 @@ describe('Character proxy', () => {
     });
   });
 
+  const testDate = new Date('1990-02-31');
+  const cursorForTestDate = 'ACi7LZQA';
+
+  describe('getQueryFromCursor', () => {
+    it('will return an empty query with no cursor', () => {
+      // Arrange
+      // Act
+      const query = CharacterProxy.getQueryFromCursor(null);
+
+      // Assert
+      expect(query).toEqual({});
+    });
+
+    it('will return expected query with cursor supplied', () => {
+      // Arrange
+      // Act
+      const query = CharacterProxy.getQueryFromCursor(cursorForTestDate);
+
+      // Assert
+      expect(query).toEqual({
+        createdDate: {
+          $gte: testDate,
+        },
+      });
+    });
+  });
+
+  describe('getCursorFromElement', () => {
+    it('will return null cursor value from no element', () => {
+      // Arrange
+      // Act
+      const cursor = CharacterProxy.getCursorFromElement(null);
+
+      // Assert
+      expect(cursor).toBeNull();
+    });
+
+    it('will return null cursor value from invalid element', () => {
+      // Arrange
+      const element = {};
+
+      // Act
+      const cursor = CharacterProxy.getCursorFromElement(element);
+
+      // Assert
+      expect(cursor).toBeNull();
+    });
+
+    it('will return expected cursor value from valid element', () => {
+      // Arrange
+      const element = { createdDate: testDate };
+
+      // Act
+      const cursor = CharacterProxy.getCursorFromElement(element);
+
+      // Assert
+      expect(cursor).toEqual(cursorForTestDate);
+    });
+  });
+
   describe('getCharacterIds', () => {
+    const collection = {
+      find: jest.fn().mockReturnThis(),
+      hint: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockReturnThis(),
+      project: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      toArray: jest.fn(),
+    };
+
+    beforeEach(() => {
+      jest.spyOn(CharacterProxy, 'getQueryFromCursor');
+      jest.spyOn(CharacterProxy, 'getCursorFromElement');
+    });
+
+    afterEach(() => {
+      CharacterProxy.getQueryFromCursor.mockRestore();
+      CharacterProxy.getCursorFromElement.mockRestore();
+    });
+
     it('will invoke getDatabase when called', () => {
       // Arrange
       const proxy = new CharacterProxy();
@@ -40,17 +119,16 @@ describe('Character proxy', () => {
 
     it('will retrieve character IDs from the database', async () => {
       // Arrange
-      const expectedResult = ['123', '456'];
-      const collection = {
-        find: jest.fn().mockReturnThis(),
-        hint: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockReturnThis(),
-        project: jest.fn().mockReturnThis(),
-        toArray: jest.fn().mockResolvedValue(expectedResult),
-      };
+      const characters = [{ characterId: '123', name: 'foo' }, { characterId: '456', name: 'bar' }];
+      const query = { createdDate: { $gte: new Date() } };
+      CharacterProxy.getQueryFromCursor.mockImplementation(() => query);
+      const nextCursor = 'abcde';
+      CharacterProxy.getCursorFromElement.mockImplementation(() => nextCursor);
+      collection.toArray.mockResolvedValue(characters);
       const db = { collection: jest.fn().mockReturnValue(collection) };
+
       const proxy = new CharacterProxy();
-      proxy.getCharacterIds();
+      proxy.getCharacterIds(10, 'edcba');
 
       const callback = mockDbClient.getDatabase.mock.calls[0][0];
 
@@ -58,17 +136,51 @@ describe('Character proxy', () => {
       const result = await callback(db);
 
       // Assert
-      expect(result).toBe(expectedResult);
+      expect(result).toEqual({
+        items: [{ id: '123', name: 'foo' }, { id: '456', name: 'bar' }],
+        nextCursor,
+      });
+      expect(CharacterProxy.getQueryFromCursor).toHaveBeenCalledWith('edcba');
+      expect(CharacterProxy.getCursorFromElement).toHaveBeenCalledWith(false);
       expect(db.collection).toHaveBeenCalledWith('characters');
-      expect(collection.find).toHaveBeenCalledWith({});
+      expect(collection.find).toHaveBeenCalledWith(query);
       expect(collection.hint).toHaveBeenCalledWith('dateIdName');
       expect(collection.sort).toHaveBeenCalledWith({ createdDate: 1 });
       expect(collection.project).toHaveBeenCalledWith({
         characterId: true,
         name: true,
+        createdDate: true,
         _id: false,
       });
+      expect(collection.limit).toHaveBeenCalledWith(11);
       expect(collection.toArray).toHaveBeenCalledWith();
+    });
+
+    it('will retrieve one extra character and use the last to create the next cursor', async () => {
+      // Arrange
+      const lastCharacter = { characterId: '456', name: 'bar' };
+      const characters = [{ characterId: '123', name: 'foo' }, lastCharacter];
+      const query = { createdDate: { $gte: new Date() } };
+      CharacterProxy.getQueryFromCursor.mockImplementation(() => query);
+      const nextCursor = 'abcde';
+      CharacterProxy.getCursorFromElement.mockImplementation(() => nextCursor);
+      collection.toArray.mockResolvedValue(characters);
+      const db = { collection: jest.fn().mockReturnValue(collection) };
+
+      const proxy = new CharacterProxy();
+      proxy.getCharacterIds(1);
+
+      const callback = mockDbClient.getDatabase.mock.calls[0][0];
+
+      // Act
+      const result = await callback(db);
+
+      // Assert
+      expect(result).toEqual({
+        items: [{ id: '123', name: 'foo' }],
+        nextCursor,
+      });
+      expect(CharacterProxy.getCursorFromElement).toHaveBeenCalledWith(lastCharacter);
     });
   });
 

--- a/src/server/proxy/character-proxy/mock-proxy.js
+++ b/src/server/proxy/character-proxy/mock-proxy.js
@@ -16,7 +16,13 @@ class MockCharacterProxy {
   }
 
   async getCharacterIds() {
-    return this.store.ids;
+    return {
+      items: this.store.ids.map(id => ({
+        id,
+        name: this.store.byId[id].name,
+      })),
+      nextCursor: null,
+    };
   }
 
   async getCharacterById(characterId) {


### PR DESCRIPTION
Add limit and cursor parameters to character list REST API. limit
specifies how many results to return in one request, and cursor is an
opaque (to the caller) field that can be used to start the search
partway. The cursor value is supplied by the response from the character
list request in the nextCursor field (which will be null if there are no
more results).