### PR TITLE
GH-37: Refactor character selectors, add loading state

### DIFF
--- a/src/client/components/characters/character-list/character-list.selector.js
+++ b/src/client/components/characters/character-list/character-list.selector.js
@@ -1,12 +1,14 @@
 import { createStructuredSelector } from 'reselect';
 import {
-  getCharacterIds,
-  getSelectedCharacterId,
-  getCharacterNames,
+  getIds,
+  getSelectedId,
+  getNames,
+  getLoadingState,
 } from '../../../store/characters/characters.selectors';
 
 export default createStructuredSelector({
-  characterIds: getCharacterIds,
-  characterNames: getCharacterNames,
-  selectedId: getSelectedCharacterId,
+  characterIds: getIds(),
+  characterNames: getNames(),
+  selectedId: getSelectedId(),
+  loadingState: getLoadingState(),
 });

--- a/src/client/components/characters/character/character.selector.js
+++ b/src/client/components/characters/character/character.selector.js
@@ -1,3 +1,3 @@
-import { createGetCharacterById } from '../../../store/characters/characters.selectors';
+import { getItemById } from '../../../store/characters/characters.selectors';
 
-export default createGetCharacterById;
+export default () => getItemById((_state, props) => props.characterId);

--- a/src/client/components/characters/character/character.selector.spec.js
+++ b/src/client/components/characters/character/character.selector.spec.js
@@ -1,0 +1,36 @@
+import { getItemById } from '../../../store/characters/characters.selectors';
+import mapStateToProps from './character.selector';
+
+jest.mock('../../../store/characters/characters.selectors');
+
+describe('Character object selector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('will use the getItemById selector', () => {
+    // Arrange
+    const expectedResult = jest.fn();
+    getItemById.mockReturnValue(expectedResult);
+
+    // Act
+    const result = mapStateToProps();
+
+    // Assert
+    expect(result).toBe(expectedResult);
+    expect(getItemById).toHaveBeenCalledTimes(1);
+    expect(getItemById).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('will pass a props selector that gets characterId to getItemById', () => {
+    // Arrange
+    mapStateToProps();
+    const propsSelector = getItemById.mock.calls[0][0];
+
+    // Act
+    const result = propsSelector(null, { characterId: 'foo' });
+
+    // Assert
+    expect(result).toEqual('foo');
+  });
+});

--- a/src/client/components/characters/new-character/new-character.selector.js
+++ b/src/client/components/characters/new-character/new-character.selector.js
@@ -1,6 +1,6 @@
 import { createStructuredSelector } from 'reselect';
-import { getCharacterIds } from '../../../store/characters/characters.selectors';
+import { getIds } from '../../../store/characters/characters.selectors';
 
 export default createStructuredSelector({
-  characterIds: getCharacterIds,
+  characterIds: getIds(),
 });

--- a/src/client/store/characters/characters.selectors.js
+++ b/src/client/store/characters/characters.selectors.js
@@ -1,13 +1,18 @@
 import delve from 'dlv';
 import CollectionBaseSelectors from '../collection-base/collection-base.selectors';
 
-const charactersSelectors = new CollectionBaseSelectors(state => delve(state, 'characters', {}));
+class CharactersSelectors extends CollectionBaseSelectors {
+  constructor() {
+    super(state => delve(state, 'characters', {}));
+  }
+}
 
-export const getCharacterIds = charactersSelectors.getIds();
+const charactersSelectors = new CharactersSelectors();
 
-export const getCharacterNames = charactersSelectors.getNames();
-
-export const getSelectedCharacterId = charactersSelectors.getSelectedId();
-
-export const createGetCharacterById = () =>
-  charactersSelectors.getItemById((_state, props) => props.characterId);
+export const {
+  getIds,
+  getNames,
+  getSelectedId,
+  getItemById,
+  getLoadingState,
+} = charactersSelectors;

--- a/src/client/store/characters/characters.selectors.spec.js
+++ b/src/client/store/characters/characters.selectors.spec.js
@@ -1,12 +1,9 @@
 import {
-  getCharacterIds,
-  getCharacterNames,
-  getSelectedCharacterId,
-  createGetCharacterById,
+  getIds, getNames, getSelectedId, getItemById,
 } from './characters.selectors';
 
 describe('Character store selectors', () => {
-  describe('getCharacterIds', () => {
+  describe('getIds', () => {
     it('will select the list of character ids', () => {
       // Arrange
       const state = {
@@ -16,14 +13,14 @@ describe('Character store selectors', () => {
       };
 
       // Act
-      const result = getCharacterIds(state);
+      const result = getIds()(state);
 
       // Assert
       expect(result).toEqual(['1a1', '3a3', '2a2']);
     });
   });
 
-  describe('getCharacterNames', () => {
+  describe('getNames', () => {
     it('will get an object with all of the character names', () => {
       // Arrange
       const state = {
@@ -36,7 +33,7 @@ describe('Character store selectors', () => {
       };
 
       // Act
-      const result = getCharacterNames(state);
+      const result = getNames()(state);
 
       // Assert
       expect(result).toEqual({
@@ -46,7 +43,7 @@ describe('Character store selectors', () => {
     });
   });
 
-  describe('getSelectedCharacterId', () => {
+  describe('getSelectedId', () => {
     it('will get the selected character id', () => {
       // Arrange
       const state = {
@@ -56,14 +53,14 @@ describe('Character store selectors', () => {
       };
 
       // Act
-      const result = getSelectedCharacterId(state);
+      const result = getSelectedId()(state);
 
       // Assert
       expect(result).toEqual('12345');
     });
   });
 
-  describe('createGetCharacterById', () => {
+  describe('getItemById', () => {
     it('will create a selector that gets a selected character', () => {
       // Arrange
       const state = {
@@ -74,7 +71,7 @@ describe('Character store selectors', () => {
           },
         },
       };
-      const getCharacterById = createGetCharacterById();
+      const getCharacterById = getItemById((_state, props) => props.characterId);
 
       // Act
       const result = getCharacterById(state, { characterId: '2a2' });

--- a/src/client/store/collection-base/collection-base.selectors.js
+++ b/src/client/store/collection-base/collection-base.selectors.js
@@ -8,6 +8,17 @@ import { createSelector } from 'reselect';
  */
 
 /**
+ * Information about the loading status of a store object supported by a backing store.
+ * @typedef {Object} LoadingState
+ * @property {boolean} pending   True if the object has not yet been loaded.
+ * @property {boolean} loading   True if an object load is in progress.
+ * @property {boolean} loaded    True if an object load is complete.
+ * @property {string} nextCursor A value that can be used to get an additional page of results.
+ * @property {any} error         An object that contains error information about the most recent
+ *                               failed attempt to load the object.
+ */
+
+/**
  * @typedef {Object} CollectionRoot
  * @property {{[id:string]:CollectionItem}} CollectionRoot.byId
  * @property {string[]} CollectionRoot.ids
@@ -21,49 +32,57 @@ class CollectionBaseSelectors {
    */
   constructor(rootSelector) {
     this.rootSelector = rootSelector;
+    this.memoizedRootNodeSelectors = {};
   }
+
+  /**
+   * Creates a selector that gets one of the root properties of the collection
+   * store node.
+   * Not intended to be used directly by components.
+   *
+   * @param {string} key
+   *   The key into the root collection store node.
+   * @param {any} defaultValue
+   *   The value to return if the root collection has no value for the specified key.
+   * @returns {(state:*)=>any}
+   *   A selector that gets the relevant key from the root of the collection store.
+   */
+  getRootNodeSelector = (key, defaultValue) => {
+    this.memoizedRootNodeSelectors[key] = this.memoizedRootNodeSelectors[key]
+      || createSelector(
+        this.rootSelector,
+        collectionRoot => delve(collectionRoot, key, defaultValue),
+      );
+    return this.memoizedRootNodeSelectors[key];
+  };
 
   /**
    * Creates a selector that gets the collection of objects indexed by id.
    * @returns {(state:*)=>{[id:string]:CollectionItem}}
    *   A selector that gets the object collection.
    */
-  getById() {
-    this.getByIdSelector = this.getByIdSelector
-      || createSelector(
-        this.rootSelector,
-        collectionRoot => delve(collectionRoot, 'byId', {}),
-      );
-    return this.getByIdSelector;
-  }
+  getById = () => this.getRootNodeSelector('byId', {});
 
   /**
    * Creates a selector that gets the collection of object IDs.
    * @returns {(state:*)=>string[]}
    *   A selector that gets the object IDs.
    */
-  getIds() {
-    this.getIdsSelector = this.getIdsSelector
-      || createSelector(
-        this.rootSelector,
-        collectionRoot => delve(collectionRoot, 'ids', []),
-      );
-    return this.getIdsSelector;
-  }
+  getIds = () => this.getRootNodeSelector('ids', []);
 
   /**
    * Creates a selector that gets a map of item names indexed by ID.
    * @returns {(state:*)=>{[id:string]:string}}
    *   A selector that gets a map of object IDs to names.
    */
-  getNames() {
+  getNames = () => {
     this.getNamesSelector = this.getNamesSelector
       || createSelector(
         this.getById(),
         byId => mapValues(byId, item => item.name),
       );
     return this.getNamesSelector;
-  }
+  };
 
   /**
    * Creates a selector that gets the selected collection ID.
@@ -71,14 +90,7 @@ class CollectionBaseSelectors {
    *   A selector that gets the selected item ID, or an empty string if
    *   no item is selected.
    */
-  getSelectedId() {
-    this.getSelectedIdSelector = this.getSelectedIdSelector
-      || createSelector(
-        this.rootSelector,
-        collectionRoot => delve(collectionRoot, 'selectedId', ''),
-      );
-    return this.getSelectedIdSelector;
-  }
+  getSelectedId = () => this.getRootNodeSelector('selectedId', '');
 
   /**
    * Creates a selector that gets the item with an ID specified by a
@@ -89,13 +101,36 @@ class CollectionBaseSelectors {
    * @returns {(state:*,props:*)=>CollectionItem}
    *   A selector that returns the item with the specified item ID.
    */
-  getItemById(idPropSelector) {
-    return createSelector(
+  getItemById = idPropSelector =>
+    createSelector(
       this.getById(),
       idPropSelector,
       (byId, id) => delve(byId, id, {}),
     );
-  }
+
+  /**
+   * Creates a selector that gets the loading state for the collection.
+   * @returns {(state:*)=>LoadingState}
+   *   The current status of operations to load the collection from the backing store.
+   */
+  getLoadingState = () => {
+    this.getLoadingStateSelector = this.getLoadingStateSelector
+      || createSelector(
+        this.getRootNodeSelector('pending', false),
+        this.getRootNodeSelector('loading', false),
+        this.getRootNodeSelector('loaded', false),
+        this.getRootNodeSelector('nextCursor', null),
+        this.getRootNodeSelector('error', null),
+        (pending, loading, loaded, nextCursor, error) => ({
+          pending,
+          loading,
+          loaded,
+          nextCursor,
+          error,
+        }),
+      );
+    return this.getLoadingStateSelector;
+  };
 }
 
 export default CollectionBaseSelectors;

--- a/src/client/store/collection-base/collection-base.selectors.spec.js
+++ b/src/client/store/collection-base/collection-base.selectors.spec.js
@@ -1,0 +1,53 @@
+import CollectionBaseSelectors from './collection-base.selectors';
+
+describe('Base selectors for all collection store nodes', () => {
+  describe('getRootNodeSelector', () => {
+    it('will get a valid selector for an arbitrary node', () => {
+      // Arrange
+      const selectors = new CollectionBaseSelectors(root => root);
+      const selectedIdSelector = selectors.getRootNodeSelector('selectedId', '');
+
+      // Act
+      const value = selectedIdSelector({ selectedId: 'foo' });
+
+      // Assert
+      expect(value).toEqual('foo');
+    });
+
+    it('will get the same selector when called twice', () => {
+      // Arrange
+      const selectors = new CollectionBaseSelectors(root => root);
+
+      // Act
+      const selectedIdSelector = selectors.getRootNodeSelector('selectedId', '');
+      const selectedIdSelectorAgain = selectors.getRootNodeSelector('selectedId', '');
+
+      // Assert
+      expect(selectedIdSelectorAgain).toBe(selectedIdSelector);
+    });
+  });
+
+  describe('getLoadingState', () => {
+    it('will get all the loading-state properties', () => {
+      // Arrange
+      const expectedLoadingState = {
+        pending: true,
+        loading: true,
+        loaded: true,
+        nextCursor: '12345',
+        error: 'mock error',
+      };
+      const state = {
+        ...expectedLoadingState,
+        otherProps: 'also exist',
+      };
+      const selectors = new CollectionBaseSelectors(root => root);
+
+      // Act
+      const loadingState = selectors.getLoadingState()(state);
+
+      // Assert
+      expect(loadingState).toEqual(expectedLoadingState);
+    });
+  });
+});


### PR DESCRIPTION
Adds a selector for the loading state of the character list store node.

Also:
* Refactors the base collection selectors to reuse code for the common scenario of selecting one node from the root.
* Refactors the character selectors to derive more cleanly from the base collection selectors.
* Move the characterId prop selector function into the Character component, since the location of the id prop is specific to the component.