### PR TITLE
GH-37: Update character list component

### DIFF
--- a/src/client/components/characters/character-list/__snapshots__/character-list.component.spec.js.snap
+++ b/src/client/components/characters/character-list/__snapshots__/character-list.component.spec.js.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CharacterList component will render More button if nextCursor is not null 1`] = `
+<ForwardRef
+  activeKey="b2b"
+  className="character-list"
+  onSelect={[MockFunction]}
+>
+  <Bootstrap(Row)>
+    <Col
+      as="div"
+      sm={3}
+    >
+      <Nav
+        as="div"
+        className="flex-column"
+        fill={false}
+        justify={false}
+        variant="pills"
+      >
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="a1a"
+          key="a1a"
+        >
+          Mock Character 1
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="b2b"
+          key="b2b"
+        >
+          Mock Character 2
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey=""
+        >
+          <MdAdd />
+        </NavLink>
+      </Nav>
+      <Button
+        active={false}
+        className="test-more-button"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="outline-primary"
+      >
+        <MdExpandMore />
+      </Button>
+    </Col>
+    <Col
+      as="div"
+      sm={9}
+    >
+      <Bootstrap(TabContent)>
+        <TabPane
+          eventKey="b2b"
+        >
+          <Connect(Character)
+            characterId="b2b"
+            selected={true}
+          />
+        </TabPane>
+        <TabPane
+          eventKey=""
+        >
+          <Connect(NewCharacter) />
+        </TabPane>
+      </Bootstrap(TabContent)>
+    </Col>
+  </Bootstrap(Row)>
+</ForwardRef>
+`;
+
 exports[`CharacterList component will render one Character component with the appropriate character ID 1`] = `
 <ForwardRef
   activeKey="b2b"
@@ -42,6 +119,172 @@ exports[`CharacterList component will render one Character component with the ap
           <MdAdd />
         </NavLink>
       </Nav>
+    </Col>
+    <Col
+      as="div"
+      sm={9}
+    >
+      <Bootstrap(TabContent)>
+        <TabPane
+          eventKey="b2b"
+        >
+          <Connect(Character)
+            characterId="b2b"
+            selected={true}
+          />
+        </TabPane>
+        <TabPane
+          eventKey=""
+        >
+          <Connect(NewCharacter) />
+        </TabPane>
+      </Bootstrap(TabContent)>
+    </Col>
+  </Bootstrap(Row)>
+</ForwardRef>
+`;
+
+exports[`CharacterList component will render spinner if loading is true 1`] = `
+<ForwardRef
+  activeKey="b2b"
+  className="character-list"
+  onSelect={[MockFunction]}
+>
+  <Bootstrap(Row)>
+    <Col
+      as="div"
+      sm={3}
+    >
+      <Nav
+        as="div"
+        className="flex-column"
+        fill={false}
+        justify={false}
+        variant="pills"
+      >
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="a1a"
+          key="a1a"
+        >
+          Mock Character 1
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="b2b"
+          key="b2b"
+        >
+          Mock Character 2
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey=""
+        >
+          <MdAdd />
+        </NavLink>
+      </Nav>
+      <div
+        className="text-center test-loading-spinner"
+      >
+        <Bootstrap(Spinner)
+          animation="border"
+          role="status"
+          size="sm"
+          variant="secondary"
+        >
+          <span
+            className="sr-only"
+          >
+            Loading...
+          </span>
+        </Bootstrap(Spinner)>
+      </div>
+    </Col>
+    <Col
+      as="div"
+      sm={9}
+    >
+      <Bootstrap(TabContent)>
+        <TabPane
+          eventKey="b2b"
+        >
+          <Connect(Character)
+            characterId="b2b"
+            selected={true}
+          />
+        </TabPane>
+        <TabPane
+          eventKey=""
+        >
+          <Connect(NewCharacter) />
+        </TabPane>
+      </Bootstrap(TabContent)>
+    </Col>
+  </Bootstrap(Row)>
+</ForwardRef>
+`;
+
+exports[`CharacterList component will render spinner if pending is true 1`] = `
+<ForwardRef
+  activeKey="b2b"
+  className="character-list"
+  onSelect={[MockFunction]}
+>
+  <Bootstrap(Row)>
+    <Col
+      as="div"
+      sm={3}
+    >
+      <Nav
+        as="div"
+        className="flex-column"
+        fill={false}
+        justify={false}
+        variant="pills"
+      >
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="a1a"
+          key="a1a"
+        >
+          Mock Character 1
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey="b2b"
+          key="b2b"
+        >
+          Mock Character 2
+        </NavLink>
+        <NavLink
+          as={[Function]}
+          disabled={false}
+          eventKey=""
+        >
+          <MdAdd />
+        </NavLink>
+      </Nav>
+      <div
+        className="text-center test-loading-spinner"
+      >
+        <Bootstrap(Spinner)
+          animation="border"
+          role="status"
+          size="sm"
+          variant="secondary"
+        >
+          <span
+            className="sr-only"
+          >
+            Loading...
+          </span>
+        </Bootstrap(Spinner)>
+      </div>
     </Col>
     <Col
       as="div"

--- a/src/client/components/characters/character-list/character-list.actions.js
+++ b/src/client/components/characters/character-list/character-list.actions.js
@@ -1,3 +1,3 @@
-import { setSelected } from '../../../store/characters/characters.actions';
+import { setSelected, getCharacterIds } from '../../../store/characters/characters.actions';
 
-export default { setSelected };
+export default { setSelected, getCharacterIds };

--- a/src/client/components/characters/character-list/character-list.component.js
+++ b/src/client/components/characters/character-list/character-list.component.js
@@ -1,52 +1,89 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Tab, Row, Col, Nav,
+  Button, Tab, Row, Col, Nav, Spinner,
 } from 'react-bootstrap';
-import { MdAdd } from 'react-icons/md';
+import { MdAdd, MdExpandMore } from 'react-icons/md';
 import Character from '../character';
 import NewCharacter from '../new-character';
 
 const CharacterList = ({
-  characterIds, characterNames, selectedId, setSelected,
-}) => (
-  <Tab.Container className="character-list" activeKey={selectedId} onSelect={setSelected}>
-    <Row>
-      <Col sm={3}>
-        <Nav variant="pills" className="flex-column">
-          {characterIds.map(id => (
-            <Nav.Link key={id} eventKey={id}>
-              {characterNames[id]}
+  characterIds,
+  characterNames,
+  selectedId,
+  setSelected,
+  loadingState: { pending, loading, nextCursor },
+  getCharacterIds,
+}) => {
+  // Using namespace so that we can spy on it. This may be changed if we find a better way
+  // to access React hooks in the shallow renderer.
+  React.useEffect(() => {
+    if (pending) {
+      getCharacterIds();
+    }
+  }, [pending, getCharacterIds]);
+
+  return (
+    <Tab.Container className="character-list" activeKey={selectedId} onSelect={setSelected}>
+      <Row>
+        <Col sm={3}>
+          <Nav variant="pills" className="flex-column">
+            {characterIds.map(id => (
+              <Nav.Link key={id} eventKey={id}>
+                {characterNames[id]}
+              </Nav.Link>
+            ))}
+            <Nav.Link eventKey="">
+              <MdAdd />
             </Nav.Link>
-          ))}
-          <Nav.Link eventKey="">
-            <MdAdd />
-          </Nav.Link>
-        </Nav>
-      </Col>
-      <Col sm={9}>
-        <Tab.Content>
-          {selectedId && (
-            <Tab.Pane eventKey={selectedId}>
-              <Character characterId={selectedId} selected />
-            </Tab.Pane>
+          </Nav>
+          {nextCursor && (
+            <Button
+              className="test-more-button"
+              variant="outline-primary"
+              onClick={() => getCharacterIds(nextCursor)}
+            >
+              <MdExpandMore />
+            </Button>
           )}
-          <Tab.Pane eventKey="">
-            <NewCharacter />
-          </Tab.Pane>
-        </Tab.Content>
-      </Col>
-    </Row>
-  </Tab.Container>
-);
+          {(pending || loading) && (
+            <div className="text-center test-loading-spinner">
+              <Spinner animation="border" size="sm" variant="secondary" role="status">
+                <span className="sr-only">Loading...</span>
+              </Spinner>
+            </div>
+          )}
+        </Col>
+        <Col sm={9}>
+          <Tab.Content>
+            {selectedId && (
+              <Tab.Pane eventKey={selectedId}>
+                <Character characterId={selectedId} selected />
+              </Tab.Pane>
+            )}
+            <Tab.Pane eventKey="">
+              <NewCharacter />
+            </Tab.Pane>
+          </Tab.Content>
+        </Col>
+      </Row>
+    </Tab.Container>
+  );
+};
 
 CharacterList.propTypes = {
   // From mapStateToProps
   characterIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   characterNames: PropTypes.objectOf(PropTypes.string).isRequired,
   selectedId: PropTypes.string,
+  loadingState: PropTypes.shape({
+    pending: PropTypes.bool,
+    loading: PropTypes.bool,
+    nextCursor: PropTypes.string,
+  }).isRequired,
   // From mapDispatchToProps
   setSelected: PropTypes.func.isRequired,
+  getCharacterIds: PropTypes.func.isRequired,
 };
 
 CharacterList.defaultProps = {

--- a/src/client/components/characters/character-list/character-list.component.spec.js
+++ b/src/client/components/characters/character-list/character-list.component.spec.js
@@ -11,8 +11,18 @@ describe('CharacterList component', () => {
       b2b: 'Mock Character 2',
     },
     selectedId: 'b2b',
+    loadingState: {
+      pending: false,
+      loading: false,
+      nextCursor: null,
+    },
     setSelected: jest.fn(),
+    getCharacterIds: jest.fn(),
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('will render one Character component with the appropriate character ID', () => {
     // Arrange
@@ -23,5 +33,125 @@ describe('CharacterList component', () => {
 
     // Assert
     expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  describe('useEffect', () => {
+    beforeEach(() => {
+      jest.spyOn(React, 'useEffect');
+    });
+
+    afterEach(() => {
+      React.useEffect.mockRestore();
+    });
+
+    it('will set up useEffect hook', () => {
+      // Arrange
+      const props = defaultProps;
+
+      // Act
+      shallow(<CharacterList {...props} />);
+
+      // Assert
+      expect(React.useEffect).toHaveBeenCalledTimes(1);
+      expect(React.useEffect).toHaveBeenCalledWith(expect.any(Function), [
+        false,
+        expect.any(Function),
+      ]);
+    });
+
+    it('will not invoke getCharacterIds if not pending', () => {
+      // Arrange
+      const props = defaultProps;
+      shallow(<CharacterList {...props} />);
+      const effectFunc = React.useEffect.mock.calls[0][0];
+
+      // Act
+      effectFunc();
+
+      // Assert
+      expect(props.getCharacterIds).not.toHaveBeenCalled();
+    });
+
+    it('will invoke getCharacterIds if pending', () => {
+      // Arrange
+      const props = { ...defaultProps, loadingState: { pending: true } };
+      shallow(<CharacterList {...props} />);
+      const effectFunc = React.useEffect.mock.calls[0][0];
+
+      // Act
+      effectFunc();
+
+      // Assert
+      expect(props.getCharacterIds).toHaveBeenCalledTimes(1);
+      expect(props.getCharacterIds).toHaveBeenCalledWith();
+    });
+  });
+
+  it('will render spinner if pending is true', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+      loadingState: {
+        pending: true,
+      },
+    };
+
+    // Act
+    const wrapper = shallow(<CharacterList {...props} />);
+
+    // Assert
+    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('.test-loading-spinner').length).toEqual(1);
+  });
+
+  it('will render spinner if loading is true', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+      loadingState: {
+        loading: true,
+      },
+    };
+
+    // Act
+    const wrapper = shallow(<CharacterList {...props} />);
+
+    // Assert
+    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('.test-loading-spinner').length).toEqual(1);
+  });
+
+  it('will render More button if nextCursor is not null', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+      loadingState: {
+        nextCursor: '12345',
+      },
+    };
+
+    // Act
+    const wrapper = shallow(<CharacterList {...props} />);
+
+    // Assert
+    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('.test-more-button').length).toEqual(1);
+  });
+
+  it('will invoke getCharacterIds if More button is clicked', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+      loadingState: {
+        nextCursor: '12345',
+      },
+    };
+    const wrapper = shallow(<CharacterList {...props} />);
+
+    // Act
+    wrapper.find('.test-more-button').simulate('click');
+
+    // Assert
+    expect(props.getCharacterIds).toHaveBeenCalledWith('12345');
   });
 });

--- a/src/client/store/characters/characters.initial-state.js
+++ b/src/client/store/characters/characters.initial-state.js
@@ -41,6 +41,7 @@ export default {
       },
     },
   },
-  ids: ['a1', 'b2'],
-  selectedId: 'b2',
+  ids: [],
+  selectedId: null,
+  pending: true,
 };


### PR DESCRIPTION
Character list component will now trigger the initial load of character IDs when rendered (assuming that characters.pending is true, which should only be the case when the characters store is reset).

Includes loading spinner to display while loading is in progress and a "more" button that can be clicked to return additional pages of character data.