### PR TITLE
GH-43: Add API actions and reducers for PATCH and DELETE

### DIFF
--- a/src/client/store/characters/characters.actions.js
+++ b/src/client/store/characters/characters.actions.js
@@ -2,10 +2,23 @@ import createCollectionActions from '../collection-base/collection-base.actions'
 import { createApiAction } from '../api/api.action-creator';
 import CharacterActionOptions from './characters.constants';
 
+/**
+ * @typedef {import('../../../server/proxy/character-proxy').Character} Character
+ * @typedef {import('redux-thunk').ThunkAction} ThunkAction
+ */
+
 export const { add: addCharacter, setSelected, setName } = createCollectionActions(
   CharacterActionOptions,
 );
 
+/**
+ * Issue an API request to get part of the list of characters.
+ * @type {(cursor:string,limit:number)=>ThunkAction}
+ * @param {string} cursor
+ *  A token to the page of results to get.
+ * @param {number} limit
+ *  The number of characters to get.
+ */
 export const getCharacterIds = createApiAction('CHARACTER.GET_CHARACTER_IDS', (cursor, limit) => ({
   request: {
     method: 'get',
@@ -14,6 +27,10 @@ export const getCharacterIds = createApiAction('CHARACTER.GET_CHARACTER_IDS', (c
   },
 }));
 
+/**
+ * Issue an API request to get a character.
+ * @type {(characterId:string)=>ThunkAction}
+ */
 export const getCharacterById = createApiAction('CHARACTER.GET_CHARACTER_BY_ID', characterId => ({
   characterId,
   request: {
@@ -22,6 +39,10 @@ export const getCharacterById = createApiAction('CHARACTER.GET_CHARACTER_BY_ID',
   },
 }));
 
+/**
+ * Issue an API request to create a new character.
+ * @type {(character:Character)=>ThunkAction}
+ */
 export const createCharacter = createApiAction(
   'CHARACTER.CREATE_CHARACTER',
   character => ({
@@ -39,3 +60,35 @@ export const createCharacter = createApiAction(
     },
   }),
 );
+
+/**
+ * Issue an API request to modify a character.
+ * @type {(characterId:string,character:Character)=>import('redux-thunk').ThunkAction}
+ */
+export const patchCharacter = createApiAction(
+  'CHARACTER.PATCH_CHARACTER',
+  (characterId, character) => ({
+    characterId,
+    character,
+    request: {
+      method: 'patch',
+      url: `/characters/${encodeURIComponent(characterId)}`,
+      data: character,
+    },
+  }),
+);
+
+// If a scenario for replace comes up, uncomment this
+// export const replaceCharacter = createApiAction('CHARACTER.REPLACE_CHARACTER', () => ({}));
+
+/**
+ * Issue an API request to delete a character.
+ * @type {(characterId:string)=>ThunkAction}
+ */
+export const deleteCharacter = createApiAction('CHARACTER.DELETE_CHARACTER', characterId => ({
+  characterId,
+  request: {
+    method: 'delete',
+    url: `/characters/${encodeURIComponent(characterId)}`,
+  },
+}));

--- a/src/client/store/characters/characters.actions.spec.js
+++ b/src/client/store/characters/characters.actions.spec.js
@@ -2,6 +2,8 @@ import {
   getCharacterIds,
   getCharacterById,
   createCharacter,
+  patchCharacter,
+  deleteCharacter,
   addCharacter,
 } from './characters.actions';
 
@@ -128,6 +130,63 @@ describe('Character actions', () => {
 
       // Assert
       expect(dispatch).toHaveBeenCalledWith(expectedAddAction);
+    });
+  });
+
+  describe('patchCharacter', () => {
+    it('will have the expected arguments', () => {
+      // Arrange
+      // Act
+      // Assert
+      expect(patchCharacter).toEqual(['CHARACTER.PATCH_CHARACTER', expect.any(Function)]);
+    });
+
+    it('will create the expected payload', () => {
+      // Arrange
+      const payloadCreator = patchCharacter[1];
+      const characterId = 'foo bar';
+      const character = { name: 'Baz Quux' };
+
+      // Act
+      const payload = payloadCreator(characterId, character);
+
+      // Assert
+      expect(payload).toEqual({
+        characterId,
+        character,
+        request: {
+          method: 'patch',
+          url: `/characters/${encodeURIComponent(characterId)}`,
+          data: character,
+        },
+      });
+    });
+  });
+
+  describe('deleteCharacter', () => {
+    it('will have the expected arguments', () => {
+      // Arrange
+      // Act
+      // Assert
+      expect(deleteCharacter).toEqual(['CHARACTER.DELETE_CHARACTER', expect.any(Function)]);
+    });
+
+    it('will create the expected payload', () => {
+      // Arrange
+      const payloadCreator = deleteCharacter[1];
+      const characterId = 'foo bar';
+
+      // Act
+      const payload = payloadCreator(characterId);
+
+      // Assert
+      expect(payload).toEqual({
+        characterId,
+        request: {
+          method: 'delete',
+          url: `/characters/${encodeURIComponent(characterId)}`,
+        },
+      });
     });
   });
 });

--- a/src/client/store/characters/index.js
+++ b/src/client/store/characters/index.js
@@ -1,4 +1,5 @@
 import fromPairs from 'lodash/fromPairs';
+import pickBy from 'lodash/pickBy';
 import createReducer from '../collection-base/collection-base.reducer';
 import CharacterActionOptions from './characters.constants';
 import initialState from './characters.initial-state';
@@ -105,6 +106,86 @@ export default createReducer(
         addStatus: {
           loading: false,
           error,
+        },
+      }),
+    },
+    PATCH_CHARACTER: {
+      REQUEST: (state, { payload: { characterId } }) => ({
+        ...state,
+        byId: {
+          ...state.byId,
+          [characterId]: {
+            ...state.byId[characterId],
+            patchStatus: {
+              loading: true,
+            },
+          },
+        },
+      }),
+      RESPONSE: (state, { payload: { characterId, character } }) => ({
+        ...state,
+        byId: {
+          ...state.byId,
+          [characterId]: pickBy({
+            // by default _.pickBy returns only the keys with truthy values.
+            // This takes care of removing the patchStatus node as well as any keys
+            // where the patch document value was null.
+            ...state.byId[characterId],
+            patchStatus: null,
+            ...character,
+          }),
+        },
+      }),
+      ERROR: (state, { payload: { characterId, error } }) => ({
+        ...state,
+        byId: {
+          ...state.byId,
+          [characterId]: {
+            ...state.byId[characterId],
+            patchStatus: {
+              loading: false,
+              error,
+            },
+          },
+        },
+      }),
+    },
+    DELETE_CHARACTER: {
+      REQUEST: (state, { payload: { characterId } }) => ({
+        ...state,
+        byId: {
+          ...state.byId,
+          [characterId]: {
+            ...state.byId[characterId],
+            deleteStatus: {
+              loading: true,
+            },
+          },
+        },
+      }),
+      RESPONSE: (state, { payload: { characterId } }) => ({
+        ...state,
+        byId: pickBy({
+          ...state.byId,
+          [characterId]: null,
+        }),
+        ids: state.ids.filter(id => id !== characterId),
+        selectedId:
+          state.selectedId !== characterId
+            ? state.selectedId
+            : state.ids.filter(id => id !== characterId)[0],
+      }),
+      ERROR: (state, { payload: { characterId, error } }) => ({
+        ...state,
+        byId: {
+          ...state.byId,
+          [characterId]: {
+            ...state.byId[characterId],
+            deleteStatus: {
+              loading: false,
+              error,
+            },
+          },
         },
       }),
     },

--- a/src/client/store/characters/index.spec.js
+++ b/src/client/store/characters/index.spec.js
@@ -284,4 +284,188 @@ describe('Characters store reducer', () => {
       });
     });
   });
+
+  describe('patchCharacter', () => {
+    describe('request', () => {
+      it('will set patchStatus.loading to true on the character', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.PATCH_CHARACTER.REQUEST',
+          payload: {
+            characterId: '12345',
+            character: {
+              name: 'baz',
+            },
+          },
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.byId[12345].patchStatus).toEqual({ loading: true });
+      });
+    });
+
+    describe('response', () => {
+      it('will update the character data for the specified id', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.PATCH_CHARACTER.RESPONSE',
+          payload: {
+            characterId: '12345',
+            character: {
+              name: 'baz',
+            },
+          },
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.byId[12345]).toEqual({ name: 'baz' });
+      });
+    });
+
+    describe('error', () => {
+      it('will set the error object', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.PATCH_CHARACTER.ERROR',
+          payload: { characterId: 12345, error: 'failed' },
+          error: true,
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.byId[12345]).toMatchObject({
+          patchStatus: {
+            loading: false,
+            error: 'failed',
+          },
+        });
+      });
+    });
+  });
+
+  describe('deleteCharacter', () => {
+    describe('request', () => {
+      it('will set deleteStatus.loading to true on the character', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.DELETE_CHARACTER.REQUEST',
+          payload: {
+            characterId: '12345',
+          },
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.byId[12345].deleteStatus).toEqual({ loading: true });
+      });
+    });
+
+    describe('response', () => {
+      it('will remove the character data for the specified id', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.DELETE_CHARACTER.RESPONSE',
+          payload: {
+            characterId: '12345',
+          },
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.byId[12345]).toBeFalsy();
+        expect(nextState.ids).toEqual(['54321']);
+      });
+
+      it('will not change the selected ID if a different character is deleted', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.DELETE_CHARACTER.RESPONSE',
+          payload: {
+            characterId: '54321',
+          },
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.selectedId).toEqual('12345');
+      });
+
+      it('will set the selected ID to the second character if the first character is deleted', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.DELETE_CHARACTER.RESPONSE',
+          payload: {
+            characterId: '12345',
+          },
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.selectedId).toEqual('54321');
+      });
+
+      it('will set the selected ID to nothing if the only character is deleted', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.DELETE_CHARACTER.RESPONSE',
+          payload: {
+            characterId: '12345',
+          },
+        };
+        const testState = {
+          selectedId: '12345',
+          byId: {
+            12345: state.byId[12345],
+          },
+          ids: ['12345'],
+        };
+
+        // Act
+        const nextState = charactersReducer(testState, action);
+
+        // Assert
+        expect(nextState.selectedId).toBeFalsy();
+        expect(nextState.byId).toEqual({});
+        expect(nextState.ids).toEqual([]);
+      });
+    });
+
+    describe('error', () => {
+      it('will set the error object', () => {
+        // Arrange
+        const action = {
+          type: 'CHARACTER.DELETE_CHARACTER.ERROR',
+          payload: { characterId: 12345, error: 'failed' },
+          error: true,
+        };
+
+        // Act
+        const nextState = charactersReducer(state, action);
+
+        // Assert
+        expect(nextState.byId[12345]).toMatchObject({
+          deleteStatus: {
+            loading: false,
+            error: 'failed',
+          },
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add API actions that will invoke the per-character PATCH and DELETE verbs, and the corresponding reducers that will update state accordingly.

The PATCH action will set `{ patchStatus: { loading: true } }` on the character being patched when the request begins, update the character according to the patch value when the request completes, and set an error object inside `patchStatus` when the request fails.

The DELETE action will set `{ deleteStatus: { loading: true } }` on the character being deleted when the request begins, remove the character from the store when the request completes, and set an error object inside `deleteStatus` when the request fails. On successful deletion, the `selectedId` prop will be set to the first remaining character, or left empty if the last character is deleted.