### PR TITLE
GH-43: Add support for deleting characters

### DIFF
--- a/src/client/components/characters/character/__snapshots__/character.component.spec.js.snap
+++ b/src/client/components/characters/character/__snapshots__/character.component.spec.js.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Character component will bring up delete modal dialog if delete button is clicked 1`] = `
+<Card
+  as="div"
+  body={false}
+  className="character"
+  key="b2b"
+>
+  <CardHeader
+    as="h5"
+    className="bg-primary text-white"
+  >
+    <Bootstrap(Row)>
+      <Col
+        as="div"
+      >
+        <ClickableEdit
+          loading={false}
+          setText={[Function]}
+          text="Mock name"
+        />
+      </Col>
+      <Col
+        as="div"
+        className="px-0"
+        xs="auto"
+      >
+        <Button
+          active={false}
+          className="delete-button"
+          disabled={false}
+          onClick={[Function]}
+          size="sm"
+          type="button"
+          variant="primary"
+        >
+          <MdDelete />
+        </Button>
+        <DeleteCharacterModal
+          name="Mock name"
+          onCancel={[Function]}
+          onConfirm={[Function]}
+          show={true}
+        />
+      </Col>
+    </Bootstrap(Row)>
+  </CardHeader>
+  <CardBody>
+    <CardText>
+      Skills go here
+    </CardText>
+  </CardBody>
+</Card>
+`;
+
 exports[`Character component will display a loading spinner if loading is true 1`] = `
 <Card
   as="div"
@@ -11,11 +65,40 @@ exports[`Character component will display a loading spinner if loading is true 1
     as="h5"
     className="bg-primary text-white"
   >
-    <ClickableEdit
-      loading={false}
-      setText={[Function]}
-      text="Mock name"
-    />
+    <Bootstrap(Row)>
+      <Col
+        as="div"
+      >
+        <ClickableEdit
+          loading={false}
+          setText={[Function]}
+          text="Mock name"
+        />
+      </Col>
+      <Col
+        as="div"
+        className="px-0"
+        xs="auto"
+      >
+        <Button
+          active={false}
+          className="delete-button"
+          disabled={false}
+          onClick={[Function]}
+          size="sm"
+          type="button"
+          variant="primary"
+        >
+          <MdDelete />
+        </Button>
+        <DeleteCharacterModal
+          name="Mock name"
+          onCancel={[Function]}
+          onConfirm={[Function]}
+          show={false}
+        />
+      </Col>
+    </Bootstrap(Row)>
   </CardHeader>
   <CardBody>
     <Bootstrap(Spinner)
@@ -45,11 +128,40 @@ exports[`Character component will display a loading spinner if pending is true 1
     as="h5"
     className="bg-primary text-white"
   >
-    <ClickableEdit
-      loading={false}
-      setText={[Function]}
-      text="Mock name"
-    />
+    <Bootstrap(Row)>
+      <Col
+        as="div"
+      >
+        <ClickableEdit
+          loading={false}
+          setText={[Function]}
+          text="Mock name"
+        />
+      </Col>
+      <Col
+        as="div"
+        className="px-0"
+        xs="auto"
+      >
+        <Button
+          active={false}
+          className="delete-button"
+          disabled={false}
+          onClick={[Function]}
+          size="sm"
+          type="button"
+          variant="primary"
+        >
+          <MdDelete />
+        </Button>
+        <DeleteCharacterModal
+          name="Mock name"
+          onCancel={[Function]}
+          onConfirm={[Function]}
+          show={false}
+        />
+      </Col>
+    </Bootstrap(Row)>
   </CardHeader>
   <CardBody>
     <Bootstrap(Spinner)
@@ -79,11 +191,90 @@ exports[`Character component will render Character component 1`] = `
     as="h5"
     className="bg-primary text-white"
   >
-    <ClickableEdit
-      loading={false}
-      setText={[Function]}
-      text="Mock name"
-    />
+    <Bootstrap(Row)>
+      <Col
+        as="div"
+      >
+        <ClickableEdit
+          loading={false}
+          setText={[Function]}
+          text="Mock name"
+        />
+      </Col>
+      <Col
+        as="div"
+        className="px-0"
+        xs="auto"
+      >
+        <Button
+          active={false}
+          className="delete-button"
+          disabled={false}
+          onClick={[Function]}
+          size="sm"
+          type="button"
+          variant="primary"
+        >
+          <MdDelete />
+        </Button>
+        <DeleteCharacterModal
+          name="Mock name"
+          onCancel={[Function]}
+          onConfirm={[Function]}
+          show={false}
+        />
+      </Col>
+    </Bootstrap(Row)>
+  </CardHeader>
+  <CardBody>
+    <CardText>
+      Skills go here
+    </CardText>
+  </CardBody>
+</Card>
+`;
+
+exports[`Character component will replace delete button with a spinner if deleteCharacter is in progress 1`] = `
+<Card
+  as="div"
+  body={false}
+  className="character"
+  key="b2b"
+>
+  <CardHeader
+    as="h5"
+    className="bg-primary text-white"
+  >
+    <Bootstrap(Row)>
+      <Col
+        as="div"
+      >
+        <ClickableEdit
+          loading={false}
+          setText={[Function]}
+          text="Mock name"
+        />
+      </Col>
+      <Col
+        as="div"
+        className="px-0"
+        xs="auto"
+      >
+        <Bootstrap(Spinner)
+          animation="border"
+          className="test-deleting-spinner"
+          role="status"
+          size="sm"
+          variant="light"
+        >
+          <span
+            className="sr-only"
+          >
+            Deleting...
+          </span>
+        </Bootstrap(Spinner)>
+      </Col>
+    </Bootstrap(Row)>
   </CardHeader>
   <CardBody>
     <CardText>
@@ -104,11 +295,40 @@ exports[`Character component will set ClickableEdit.loading to true if patchChar
     as="h5"
     className="bg-primary text-white"
   >
-    <ClickableEdit
-      loading={true}
-      setText={[Function]}
-      text="Mock name"
-    />
+    <Bootstrap(Row)>
+      <Col
+        as="div"
+      >
+        <ClickableEdit
+          loading={true}
+          setText={[Function]}
+          text="Mock name"
+        />
+      </Col>
+      <Col
+        as="div"
+        className="px-0"
+        xs="auto"
+      >
+        <Button
+          active={false}
+          className="delete-button"
+          disabled={false}
+          onClick={[Function]}
+          size="sm"
+          type="button"
+          variant="primary"
+        >
+          <MdDelete />
+        </Button>
+        <DeleteCharacterModal
+          name="Mock name"
+          onCancel={[Function]}
+          onConfirm={[Function]}
+          show={false}
+        />
+      </Col>
+    </Bootstrap(Row)>
   </CardHeader>
   <CardBody>
     <CardText>

--- a/src/client/components/characters/character/__snapshots__/delete-character-modal.spec.js.snap
+++ b/src/client/components/characters/character/__snapshots__/delete-character-modal.spec.js.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal dialog box for deleting a character will render hidden if show is false 1`] = `
+<Bootstrap(Modal)
+  onHide={[MockFunction]}
+  show={false}
+>
+  <ModalHeader
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle>
+      Confirm Delete
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    Really delete character John Doe?
+  </ModalBody>
+  <ModalFooter>
+    <Button
+      active={false}
+      className="delete-button-cancel"
+      disabled={false}
+      onClick={[MockFunction]}
+      type="button"
+      variant="secondary"
+    >
+      Keep
+    </Button>
+    <Button
+      active={false}
+      className="delete-button-confirm"
+      disabled={false}
+      onClick={[MockFunction]}
+      type="button"
+      variant="primary"
+    >
+      Delete
+    </Button>
+  </ModalFooter>
+</Bootstrap(Modal)>
+`;
+
+exports[`Modal dialog box for deleting a character will render normally if show is false 1`] = `
+<Bootstrap(Modal)
+  onHide={[MockFunction]}
+  show={true}
+>
+  <ModalHeader
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle>
+      Confirm Delete
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    Really delete character John Doe?
+  </ModalBody>
+  <ModalFooter>
+    <Button
+      active={false}
+      className="delete-button-cancel"
+      disabled={false}
+      onClick={[MockFunction]}
+      type="button"
+      variant="secondary"
+    >
+      Keep
+    </Button>
+    <Button
+      active={false}
+      className="delete-button-confirm"
+      disabled={false}
+      onClick={[MockFunction]}
+      type="button"
+      variant="primary"
+    >
+      Delete
+    </Button>
+  </ModalFooter>
+</Bootstrap(Modal)>
+`;

--- a/src/client/components/characters/character/character.actions.js
+++ b/src/client/components/characters/character/character.actions.js
@@ -1,7 +1,7 @@
 import {
   getCharacterById,
   patchCharacter,
-  // deleteCharacter,
+  deleteCharacter,
 } from '../../../store/characters/characters.actions';
 
-export default { getCharacterById, patchCharacter /* , deleteCharacter */ };
+export default { getCharacterById, patchCharacter, deleteCharacter };

--- a/src/client/components/characters/character/character.component.js
+++ b/src/client/components/characters/character/character.component.js
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Card, Spinner } from 'react-bootstrap';
+import {
+  Card, Row, Col, Spinner, Button,
+} from 'react-bootstrap';
+import { MdDelete } from 'react-icons/md';
 import ClickableEdit from '../../controls/clickable-edit';
+import DeleteCharacterModal from './delete-character-modal';
 
 const Character = ({
   characterId,
@@ -9,10 +13,10 @@ const Character = ({
   pending,
   loading,
   patchStatus: { loading: patchLoading },
-  // deleteStatus: { loading: deleteLoading },
+  deleteStatus: { loading: deleteLoading },
   getCharacterById,
   patchCharacter,
-  // deleteCharacter,
+  deleteCharacter,
 }) => {
   // Using namespace so that we can spy on it. This may be changed if we find a better way
   // to access React hooks in the shallow renderer.
@@ -21,15 +25,49 @@ const Character = ({
       getCharacterById(characterId);
     }
   }, [pending]);
+  const [isDeleteModal, setDeleteModal] = useState(false);
+
   const loaded = !(pending || loading);
   return (
     <Card key={characterId} className="character">
       <Card.Header as="h5" className="bg-primary text-white">
-        <ClickableEdit
-          text={name}
-          setText={newName => patchCharacter(characterId, { name: newName })}
-          loading={patchLoading}
-        />
+        <Row>
+          <Col>
+            <ClickableEdit
+              text={name}
+              setText={newName => patchCharacter(characterId, { name: newName })}
+              loading={patchLoading}
+            />
+          </Col>
+          <Col xs="auto" className="px-0">
+            {deleteLoading ? (
+              <Spinner
+                className="test-deleting-spinner"
+                size="sm"
+                animation="border"
+                variant="light"
+                role="status"
+              >
+                <span className="sr-only">Deleting...</span>
+              </Spinner>
+            ) : (
+              <>
+                <Button className="delete-button" size="sm" onClick={() => setDeleteModal(true)}>
+                  <MdDelete />
+                </Button>
+                <DeleteCharacterModal
+                  name={name}
+                  show={isDeleteModal}
+                  onCancel={() => setDeleteModal(false)}
+                  onConfirm={() => {
+                    deleteCharacter(characterId);
+                    setDeleteModal(false);
+                  }}
+                />
+              </>
+            )}
+          </Col>
+        </Row>
       </Card.Header>
       <Card.Body>
         {loaded ? (
@@ -62,15 +100,15 @@ Character.propTypes = {
       message: PropTypes.string,
     }),
   }),
-  // deleteStatus: PropTypes.shape({
-  //   loading: PropTypes.bool,
-  //   error: PropTypes.shape({
-  //     message: PropTypes.string,
-  //   }),
-  // }),
+  deleteStatus: PropTypes.shape({
+    loading: PropTypes.bool,
+    error: PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  }),
   // From mapDispatchToProps
   patchCharacter: PropTypes.func.isRequired,
-  // deleteCharacter: PropTypes.func.isRequired,
+  deleteCharacter: PropTypes.func.isRequired,
   getCharacterById: PropTypes.func.isRequired,
 };
 
@@ -78,7 +116,7 @@ Character.defaultProps = {
   pending: false,
   loading: false,
   patchStatus: {},
-  // deleteStatus: {},
+  deleteStatus: {},
 };
 
 export default Character;

--- a/src/client/components/characters/character/character.component.spec.js
+++ b/src/client/components/characters/character/character.component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import ClickableEdit from '../../controls/clickable-edit';
+import DeleteCharacterModal from './delete-character-modal';
 import Character from './character.component';
 
 describe('Character component', () => {
@@ -59,6 +60,75 @@ describe('Character component', () => {
 
     // Assert
     expect(props.patchCharacter).toHaveBeenCalledWith(props.characterId, { name: 'new text' });
+  });
+
+  it('will replace delete button with a spinner if deleteCharacter is in progress', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+      deleteStatus: {
+        loading: true,
+      },
+    };
+
+    // Act
+    const wrapper = shallow(<Character {...props} />);
+
+    // Assert
+    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('.test-deleting-spinner').length).toEqual(1);
+    expect(wrapper.find('.delete-button').length).toEqual(0);
+  });
+
+  it('will bring up delete modal dialog if delete button is clicked', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+    };
+    const wrapper = shallow(<Character {...props} />);
+
+    // Act
+    wrapper.find('.delete-button').simulate('click');
+
+    // Assert
+    expect(toJson(wrapper)).toMatchSnapshot();
+    const deleteModal = wrapper.find(DeleteCharacterModal);
+    expect(deleteModal.prop('show')).toBeTruthy();
+  });
+
+  it('will dismiss delete modal dialog if it calls onCancel', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+    };
+    const wrapper = shallow(<Character {...props} />);
+    wrapper.find('.delete-button').simulate('click');
+
+    // Act
+    const onDeleteCancel = wrapper.find(DeleteCharacterModal).prop('onCancel');
+    onDeleteCancel();
+
+    // Assert
+    expect(wrapper.find(DeleteCharacterModal).prop('show')).toBeFalsy();
+    expect(props.deleteCharacter).not.toHaveBeenCalled();
+  });
+
+  it('will dismiss delete modal dialog and trigger delete if it calls onConfirm', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+    };
+    const wrapper = shallow(<Character {...props} />);
+    wrapper.find('.delete-button').simulate('click');
+
+    // Act
+    const onDeleteConfirm = wrapper.find(DeleteCharacterModal).prop('onConfirm');
+    onDeleteConfirm();
+
+    // Assert
+    expect(wrapper.find(DeleteCharacterModal).prop('show')).toBeFalsy();
+    expect(props.deleteCharacter).toHaveBeenCalledTimes(1);
+    expect(props.deleteCharacter).toHaveBeenCalledWith(props.characterId);
   });
 
   it('will display a loading spinner if pending is true', () => {

--- a/src/client/components/characters/character/delete-character-modal.js
+++ b/src/client/components/characters/character/delete-character-modal.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Modal } from 'react-bootstrap';
+
+const DeleteCharacterModal = ({
+  name, show, onCancel, onConfirm,
+}) => (
+  <Modal show={show} onHide={onCancel}>
+    <Modal.Header closeButton>
+      <Modal.Title>Confirm Delete</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>{`Really delete character ${name}?`}</Modal.Body>
+    <Modal.Footer>
+      <Button className="delete-button-cancel" variant="secondary" onClick={onCancel}>
+        Keep
+      </Button>
+      <Button className="delete-button-confirm" variant="primary" onClick={onConfirm}>
+        Delete
+      </Button>
+    </Modal.Footer>
+  </Modal>
+);
+
+DeleteCharacterModal.propTypes = {
+  name: PropTypes.string.isRequired,
+  show: PropTypes.bool.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+};
+
+export default DeleteCharacterModal;

--- a/src/client/components/characters/character/delete-character-modal.spec.js
+++ b/src/client/components/characters/character/delete-character-modal.spec.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import DeleteCharacterModal from './delete-character-modal';
+
+describe('Modal dialog box for deleting a character', () => {
+  const defaultProps = {
+    name: 'John Doe',
+    show: true,
+    onCancel: jest.fn(),
+    onConfirm: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('will render normally if show is false', () => {
+    // Arrange
+    const props = defaultProps;
+
+    // Act
+    const wrapper = shallow(<DeleteCharacterModal {...props} />);
+
+    // Assert
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('will render hidden if show is false', () => {
+    // Arrange
+    const props = {
+      ...defaultProps,
+      show: false,
+    };
+
+    // Act
+    const wrapper = shallow(<DeleteCharacterModal {...props} />);
+
+    // Assert
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('will call onCancel when closed', () => {
+    // Arrange
+    const props = defaultProps;
+    const wrapper = shallow(<DeleteCharacterModal {...props} />);
+
+    // Act
+    const onHide = wrapper.find(Modal).prop('onHide');
+    onHide();
+
+    // Assert
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+    expect(props.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('will call onCancel when cancel button is clicked', () => {
+    // Arrange
+    const props = defaultProps;
+    const wrapper = shallow(<DeleteCharacterModal {...props} />);
+
+    // Act
+    wrapper.find('.delete-button-cancel').simulate('click');
+
+    // Assert
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+    expect(props.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('will call onConfirm when confirm button is clicked', () => {
+    // Arrange
+    const props = defaultProps;
+    const wrapper = shallow(<DeleteCharacterModal {...props} />);
+
+    // Act
+    wrapper.find('.delete-button-confirm').simulate('click');
+
+    // Assert
+    expect(props.onCancel).not.toHaveBeenCalled();
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/client/components/controls/__snapshots__/clickable-edit.spec.js.snap
+++ b/src/client/components/controls/__snapshots__/clickable-edit.spec.js.snap
@@ -18,7 +18,7 @@ exports[`ClickableEdit common component will disable the edit button if loading 
         className="test-loading-spinner"
         role="status"
         size="sm"
-        variant="secondary"
+        variant="light"
       />
     </Col>
     <Col
@@ -70,7 +70,7 @@ exports[`ClickableEdit common component will disable the save and cancel buttons
         className="test-loading-spinner"
         role="status"
         size="sm"
-        variant="secondary"
+        variant="light"
       />
     </Col>
     <Col

--- a/src/client/components/controls/clickable-edit.js
+++ b/src/client/components/controls/clickable-edit.js
@@ -37,7 +37,7 @@ const ClickableEdit = ({ text, setText, loading }) => {
               className="test-loading-spinner"
               size="sm"
               animation="border"
-              variant="secondary"
+              variant="light"
               role="status"
             />
           </Col>
@@ -64,7 +64,7 @@ const ClickableEdit = ({ text, setText, loading }) => {
               className="test-loading-spinner"
               size="sm"
               animation="border"
-              variant="secondary"
+              variant="light"
               role="status"
             />
           </Col>


### PR DESCRIPTION
Adds a UI path for deleting a character.

The UI is a delete button on the header bar of the selected character; when clicked it pops up a modal with cancel and confirm buttons. The cancel button will dismiss the modal; the confirm button dismisses the modal and replaces the delete button with a spinner. Once the delete completes, the spinner (and the deleted character) disappears.

Also includes a minor tweak to the async mode for ClickableEdit to make the spinners look better on the default dark background of the edit control.