### PR TITLE
GH-53: Modify ClickableEdit to have a robust async mode

### DIFF
--- a/src/client/components/characters/character/__snapshots__/character.component.spec.js.snap
+++ b/src/client/components/characters/character/__snapshots__/character.component.spec.js.snap
@@ -16,6 +16,7 @@ exports[`Character component will bring up delete modal dialog if delete button 
         as="div"
       >
         <ClickableEdit
+          errorMessage={null}
           loading={false}
           setText={[Function]}
           text="Mock name"
@@ -70,6 +71,7 @@ exports[`Character component will display a loading spinner if loading is true 1
         as="div"
       >
         <ClickableEdit
+          errorMessage={null}
           loading={false}
           setText={[Function]}
           text="Mock name"
@@ -133,6 +135,7 @@ exports[`Character component will display a loading spinner if pending is true 1
         as="div"
       >
         <ClickableEdit
+          errorMessage={null}
           loading={false}
           setText={[Function]}
           text="Mock name"
@@ -196,6 +199,7 @@ exports[`Character component will render Character component 1`] = `
         as="div"
       >
         <ClickableEdit
+          errorMessage={null}
           loading={false}
           setText={[Function]}
           text="Mock name"
@@ -250,6 +254,7 @@ exports[`Character component will replace delete button with a spinner if delete
         as="div"
       >
         <ClickableEdit
+          errorMessage={null}
           loading={false}
           setText={[Function]}
           text="Mock name"
@@ -300,6 +305,7 @@ exports[`Character component will set ClickableEdit.loading to true if patchChar
         as="div"
       >
         <ClickableEdit
+          errorMessage={null}
           loading={true}
           setText={[Function]}
           text="Mock name"

--- a/src/client/components/characters/character/character.component.js
+++ b/src/client/components/characters/character/character.component.js
@@ -12,7 +12,7 @@ const Character = ({
   name,
   pending,
   loading,
-  patchStatus: { loading: patchLoading },
+  patchStatus: { loading: patchLoading, error: { message: patchError } = {} },
   deleteStatus: { loading: deleteLoading },
   getCharacterById,
   patchCharacter,
@@ -35,6 +35,7 @@ const Character = ({
           <Col>
             <ClickableEdit
               text={name}
+              errorMessage={patchError}
               setText={newName => patchCharacter(characterId, { name: newName })}
               loading={patchLoading}
             />

--- a/src/client/components/characters/new-character/__snapshots__/new-character.component.spec.js.snap
+++ b/src/client/components/characters/new-character/__snapshots__/new-character.component.spec.js.snap
@@ -12,6 +12,7 @@ exports[`NewCharacter component will render a spinner in place of the edit butto
   >
     <ClickableEdit
       className="name-clickable-edit"
+      errorMessage=""
       loading={false}
       setText={[Function]}
       text="New Character"
@@ -51,6 +52,7 @@ exports[`NewCharacter component will render the expected new character form 1`] 
   >
     <ClickableEdit
       className="name-clickable-edit"
+      errorMessage=""
       loading={false}
       setText={[Function]}
       text="New Character"

--- a/src/client/components/characters/new-character/new-character.component.js
+++ b/src/client/components/characters/new-character/new-character.component.js
@@ -9,6 +9,7 @@ const NewCharacter = ({
   const defaultCharacterName = 'New Character';
   const [firstCharacterId = ''] = characterIds;
   const [name, setName] = useState(defaultCharacterName);
+  const [nameError, setNameError] = useState('');
 
   const onCancel = () => {
     setName(defaultCharacterName);
@@ -18,11 +19,25 @@ const NewCharacter = ({
     setName(defaultCharacterName);
     createCharacter({ name });
   };
+  const onSetName = (newName) => {
+    if (!newName) {
+      setNameError('Name must have a value.');
+      return true;
+    }
+    setName(newName);
+    setNameError('');
+    return false;
+  };
 
   return (
     <Card className="character">
       <Card.Header as="h5" className="bg-primary text-white">
-        <ClickableEdit className="name-clickable-edit" text={name} setText={setName} />
+        <ClickableEdit
+          className="name-clickable-edit"
+          text={name}
+          errorMessage={nameError}
+          setText={onSetName}
+        />
       </Card.Header>
       <Card.Body>
         <Card.Text>Creating a new character</Card.Text>

--- a/src/client/components/characters/new-character/new-character.component.spec.js
+++ b/src/client/components/characters/new-character/new-character.component.spec.js
@@ -54,6 +54,24 @@ describe('NewCharacter component', () => {
     expect(wrapper.find('.name-clickable-edit').props().text).toEqual('Changed Character');
   });
 
+  it('will set error message when name is committed if it is empty', () => {
+    // Arrange
+    const props = defaultProps;
+    const wrapper = shallow(<NewCharacter {...props} />);
+
+    // Act
+    wrapper
+      .find('.name-clickable-edit')
+      .props()
+      .setText('');
+
+    // Assert
+    expect(wrapper.find('.name-clickable-edit').props()).toMatchObject({
+      text: 'New Character',
+      errorMessage: 'Name must have a value.',
+    });
+  });
+
   it('will reset to default name and reset selected character ID on cancel', () => {
     // Arrange
     const props = defaultProps;

--- a/src/client/components/controls/__snapshots__/clickable-edit.spec.js.snap
+++ b/src/client/components/controls/__snapshots__/clickable-edit.spec.js.snap
@@ -1,48 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClickableEdit common component will disable the edit button if loading is true with edit mode off 1`] = `
-<div>
-  <Bootstrap(Row)>
-    <Col
-      as="div"
-    >
-      foo
-    </Col>
-    <Col
-      as="div"
-      className="px-0"
-      xs="auto"
-    >
-      <Bootstrap(Spinner)
-        animation="border"
-        className="test-loading-spinner"
-        role="status"
-        size="sm"
-        variant="light"
-      />
-    </Col>
-    <Col
-      as="div"
-      className="px-0"
-      xs="auto"
-    >
-      <Button
-        active={false}
-        className="edit-button"
-        disabled={true}
-        onClick={[Function]}
-        size="sm"
-        type="button"
-        variant="primary"
-      >
-        <MdEdit />
-      </Button>
-    </Col>
-  </Bootstrap(Row)>
-</div>
-`;
-
-exports[`ClickableEdit common component will disable the save and cancel buttons if loading is true with edit mode on 1`] = `
+exports[`ClickableEdit common component EditView will disable the save and cancel buttons if loading is true with edit mode on 1`] = `
 <Form
   as="form"
   inline={false}
@@ -54,11 +12,34 @@ exports[`ClickableEdit common component will disable the save and cancel buttons
       <FormControl
         as="input"
         className="textbox"
+        disabled={true}
+        isInvalid={false}
         onChange={[Function]}
         size="sm"
         type="text"
         value="foo"
       />
+      <Feedback
+        as="div"
+        type="invalid"
+      />
+    </Col>
+    <Col
+      as="div"
+      className="px-0"
+      xs="auto"
+    >
+      <Button
+        active={false}
+        className="cancel-button"
+        disabled={true}
+        onClick={[MockFunction]}
+        size="sm"
+        type="button"
+        variant="primary"
+      >
+        <MdCancel />
+      </Button>
     </Col>
     <Col
       as="div"
@@ -73,6 +54,34 @@ exports[`ClickableEdit common component will disable the save and cancel buttons
         variant="light"
       />
     </Col>
+  </Bootstrap(Row)>
+</Form>
+`;
+
+exports[`ClickableEdit common component EditView will render the expected initial state 1`] = `
+<Form
+  as="form"
+  inline={false}
+>
+  <Bootstrap(Row)>
+    <Col
+      as="div"
+    >
+      <FormControl
+        as="input"
+        className="textbox"
+        disabled={false}
+        isInvalid={false}
+        onChange={[Function]}
+        size="sm"
+        type="text"
+        value="foo"
+      />
+      <Feedback
+        as="div"
+        type="invalid"
+      />
+    </Col>
     <Col
       as="div"
       className="px-0"
@@ -81,8 +90,8 @@ exports[`ClickableEdit common component will disable the save and cancel buttons
       <Button
         active={false}
         className="cancel-button"
-        disabled={true}
-        onClick={[Function]}
+        disabled={false}
+        onClick={[MockFunction]}
         size="sm"
         type="button"
         variant="primary"
@@ -98,8 +107,8 @@ exports[`ClickableEdit common component will disable the save and cancel buttons
       <Button
         active={false}
         className="save-button"
-        disabled={true}
-        onClick={[Function]}
+        disabled={false}
+        onClick={[MockFunction]}
         size="sm"
         type="button"
         variant="primary"
@@ -111,7 +120,96 @@ exports[`ClickableEdit common component will disable the save and cancel buttons
 </Form>
 `;
 
-exports[`ClickableEdit common component will not set text when cancel is clicked 1`] = `
+exports[`ClickableEdit common component EditView will render the expected validation error if edit fails 1`] = `
+<Form
+  as="form"
+  inline={false}
+>
+  <Bootstrap(Row)>
+    <Col
+      as="div"
+    >
+      <FormControl
+        as="input"
+        className="textbox"
+        disabled={false}
+        isInvalid={true}
+        onChange={[Function]}
+        size="sm"
+        type="text"
+        value="foo"
+      />
+      <Feedback
+        as="div"
+        type="invalid"
+      >
+        Mock error
+      </Feedback>
+    </Col>
+    <Col
+      as="div"
+      className="px-0"
+      xs="auto"
+    >
+      <Button
+        active={false}
+        className="cancel-button"
+        disabled={false}
+        onClick={[MockFunction]}
+        size="sm"
+        type="button"
+        variant="primary"
+      >
+        <MdCancel />
+      </Button>
+    </Col>
+    <Col
+      as="div"
+      className="px-0"
+      xs="auto"
+    >
+      <Button
+        active={false}
+        className="save-button"
+        disabled={false}
+        onClick={[MockFunction]}
+        size="sm"
+        type="button"
+        variant="primary"
+      >
+        <MdSave />
+      </Button>
+    </Col>
+  </Bootstrap(Row)>
+</Form>
+`;
+
+exports[`ClickableEdit common component StaticView will hide the edit button if loading is true with edit mode off 1`] = `
+<div>
+  <Bootstrap(Row)>
+    <Col
+      as="div"
+    >
+      foo
+    </Col>
+    <Col
+      as="div"
+      className="px-0"
+      xs="auto"
+    >
+      <Bootstrap(Spinner)
+        animation="border"
+        className="test-loading-spinner"
+        role="status"
+        size="sm"
+        variant="light"
+      />
+    </Col>
+  </Bootstrap(Row)>
+</div>
+`;
+
+exports[`ClickableEdit common component StaticView will render the expected edit mode when edit is clicked 1`] = `
 <div>
   <Bootstrap(Row)>
     <Col
@@ -140,23 +238,13 @@ exports[`ClickableEdit common component will not set text when cancel is clicked
 </div>
 `;
 
-exports[`ClickableEdit common component will render expected text changes in edit mode 1`] = `
-<Form
-  as="form"
-  inline={false}
->
+exports[`ClickableEdit common component StaticView will render the expected initial state 1`] = `
+<div>
   <Bootstrap(Row)>
     <Col
       as="div"
     >
-      <FormControl
-        as="input"
-        className="textbox"
-        onChange={[Function]}
-        size="sm"
-        type="text"
-        value="bar"
-      />
+      foo
     </Col>
     <Col
       as="div"
@@ -165,147 +253,35 @@ exports[`ClickableEdit common component will render expected text changes in edi
     >
       <Button
         active={false}
-        className="cancel-button"
+        className="edit-button"
         disabled={false}
         onClick={[Function]}
         size="sm"
         type="button"
         variant="primary"
       >
-        <MdCancel />
-      </Button>
-    </Col>
-    <Col
-      as="div"
-      className="px-0"
-      xs="auto"
-    >
-      <Button
-        active={false}
-        className="save-button"
-        disabled={false}
-        onClick={[Function]}
-        size="sm"
-        type="button"
-        variant="primary"
-      >
-        <MdSave />
+        <MdEdit />
       </Button>
     </Col>
   </Bootstrap(Row)>
-</Form>
+</div>
 `;
 
 exports[`ClickableEdit common component will render the expected edit mode when edit is clicked 1`] = `
-<Form
-  as="form"
-  inline={false}
->
-  <Bootstrap(Row)>
-    <Col
-      as="div"
-    >
-      <FormControl
-        as="input"
-        className="textbox"
-        onChange={[Function]}
-        size="sm"
-        type="text"
-        value="foo"
-      />
-    </Col>
-    <Col
-      as="div"
-      className="px-0"
-      xs="auto"
-    >
-      <Button
-        active={false}
-        className="cancel-button"
-        disabled={false}
-        onClick={[Function]}
-        size="sm"
-        type="button"
-        variant="primary"
-      >
-        <MdCancel />
-      </Button>
-    </Col>
-    <Col
-      as="div"
-      className="px-0"
-      xs="auto"
-    >
-      <Button
-        active={false}
-        className="save-button"
-        disabled={false}
-        onClick={[Function]}
-        size="sm"
-        type="button"
-        variant="primary"
-      >
-        <MdSave />
-      </Button>
-    </Col>
-  </Bootstrap(Row)>
-</Form>
+<EditView
+  currentText="foo"
+  errorMessage={null}
+  loading={false}
+  onCancel={[Function]}
+  onSave={[Function]}
+  setCurrentText={[Function]}
+/>
 `;
 
-exports[`ClickableEdit common component will render the expected initial state 1`] = `
-<div>
-  <Bootstrap(Row)>
-    <Col
-      as="div"
-    >
-      foo
-    </Col>
-    <Col
-      as="div"
-      className="px-0"
-      xs="auto"
-    >
-      <Button
-        active={false}
-        className="edit-button"
-        disabled={false}
-        onClick={[Function]}
-        size="sm"
-        type="button"
-        variant="primary"
-      >
-        <MdEdit />
-      </Button>
-    </Col>
-  </Bootstrap(Row)>
-</div>
-`;
-
-exports[`ClickableEdit common component will set text when save is clicked 1`] = `
-<div>
-  <Bootstrap(Row)>
-    <Col
-      as="div"
-    >
-      foo
-    </Col>
-    <Col
-      as="div"
-      className="px-0"
-      xs="auto"
-    >
-      <Button
-        active={false}
-        className="edit-button"
-        disabled={false}
-        onClick={[Function]}
-        size="sm"
-        type="button"
-        variant="primary"
-      >
-        <MdEdit />
-      </Button>
-    </Col>
-  </Bootstrap(Row)>
-</div>
+exports[`ClickableEdit common component will render the static view by default 1`] = `
+<StaticView
+  loading={false}
+  setEditing={[Function]}
+  text="foo"
+/>
 `;

--- a/src/client/components/controls/clickable-edit.js
+++ b/src/client/components/controls/clickable-edit.js
@@ -5,70 +5,89 @@ import {
 import PropTypes from 'prop-types';
 import { MdCancel, MdSave, MdEdit } from 'react-icons/md';
 
-const ClickableEdit = ({ text, setText, loading }) => {
-  const [isEditing, setEditing] = useState(false);
-  const [currentText, setCurrentText] = useState(text);
-
-  const onCancel = () => {
-    setCurrentText(text);
-    setEditing(false);
-  };
-
-  const onSave = () => {
-    setText(currentText);
-    setEditing(false);
-  };
-
-  return isEditing ? (
-    <Form>
-      <Row>
-        <Col>
-          <Form.Control
-            className="textbox"
+const EditView = ({
+  currentText, setCurrentText, errorMessage, loading, onCancel, onSave,
+}) => (
+  <Form>
+    <Row>
+      <Col>
+        <Form.Control
+          className="textbox"
+          size="sm"
+          type="text"
+          value={currentText}
+          onChange={event => setCurrentText(event.target.value)}
+          isInvalid={!!errorMessage}
+          disabled={loading}
+        />
+        <Form.Control.Feedback type="invalid">{errorMessage}</Form.Control.Feedback>
+      </Col>
+      <Col xs="auto" className="px-0">
+        <Button className="cancel-button" size="sm" onClick={onCancel} disabled={loading}>
+          <MdCancel />
+        </Button>
+      </Col>
+      {loading ? (
+        <Col xs="auto" className="px-0">
+          <Spinner
+            className="test-loading-spinner"
             size="sm"
-            type="text"
-            value={currentText}
-            onChange={event => setCurrentText(event.target.value)}
+            animation="border"
+            variant="light"
+            role="status"
           />
         </Col>
-        {loading && (
-          <Col xs="auto" className="px-0">
-            <Spinner
-              className="test-loading-spinner"
-              size="sm"
-              animation="border"
-              variant="light"
-              role="status"
-            />
-          </Col>
-        )}
-        <Col xs="auto" className="px-0">
-          <Button className="cancel-button" size="sm" onClick={onCancel} disabled={loading}>
-            <MdCancel />
-          </Button>
-        </Col>
+      ) : (
         <Col xs="auto" className="px-0">
           <Button className="save-button" size="sm" onClick={onSave} disabled={loading}>
             <MdSave />
           </Button>
         </Col>
-      </Row>
-    </Form>
-  ) : (
-    <div>
-      <Row>
-        <Col>{text}</Col>
-        {loading && (
-          <Col xs="auto" className="px-0">
-            <Spinner
-              className="test-loading-spinner"
-              size="sm"
-              animation="border"
-              variant="light"
-              role="status"
-            />
-          </Col>
-        )}
+      )}
+    </Row>
+  </Form>
+);
+
+EditView.propTypes = {
+  currentText: PropTypes.string.isRequired,
+  setCurrentText: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  loading: PropTypes.bool.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+};
+
+EditView.defaultProps = {
+  errorMessage: null,
+};
+
+/**
+ * The static view of the ClickableEdit component.
+ * @param {Object} props
+ *  The props of the component.
+ * @param {string} props.text
+ *  The current value of the editable string.
+ * @param {boolean} props.loading
+ *  If the underlying value is editable asynchronously, this property will be
+ *  true while a set operation is in progress.
+ * @param {(editMode:boolean)=>void} props.setEditing
+ *  A method to call to enable edit mode.
+ */
+const StaticView = ({ text, loading, setEditing }) => (
+  <div>
+    <Row>
+      <Col>{text}</Col>
+      {loading ? (
+        <Col xs="auto" className="px-0">
+          <Spinner
+            className="test-loading-spinner"
+            size="sm"
+            animation="border"
+            variant="light"
+            role="status"
+          />
+        </Col>
+      ) : (
         <Col xs="auto" className="px-0">
           <Button
             className="edit-button"
@@ -79,8 +98,88 @@ const ClickableEdit = ({ text, setText, loading }) => {
             <MdEdit />
           </Button>
         </Col>
-      </Row>
-    </div>
+      )}
+    </Row>
+  </div>
+);
+
+StaticView.propTypes = {
+  text: PropTypes.string.isRequired,
+  loading: PropTypes.bool.isRequired,
+  setEditing: PropTypes.func.isRequired,
+};
+
+/**
+ * A component that allows editing a text value. It renders as a block element
+ * with a clickable button to allow editing of the value.
+ * @param {Object} props
+ *  The props of the component.
+ * @param {string} props.text
+ *  The current value of the editable string.
+ * @param {(newText:string)=>boolean} props.setText
+ *  A function to call to set the new value of the string. If the function
+ *  returns true, either the set operation is asynchronous or the set operation
+ *  failed.
+ * @param {boolean} props.loading
+ *  If the underlying value is editable asynchronously, this property will be
+ *  true while a set operation is in progress.
+ * @param {string} props.errorMessage
+ *  If the underlying value is editable asynchronosuly, this property will
+ *  have a value with a message if the set operation failed.
+ */
+const ClickableEdit = ({
+  text, setText, loading, errorMessage,
+}) => {
+  const [isEditing, setEditing] = useState(false);
+  const [currentText, setCurrentText] = useState(text);
+
+  const onCancel = () => {
+    setCurrentText(text);
+    setEditing(false);
+  };
+
+  const onSave = () => {
+    if (!setText(currentText)) {
+      setEditing(false);
+    }
+  };
+
+  React.useEffect(() => {
+    if (!loading) {
+      // Changed from loading to not loading; check error state
+      if (!errorMessage) {
+        setEditing(false);
+      }
+    }
+  }, [loading, errorMessage]);
+
+  React.useEffect(() => {
+    setCurrentText(text);
+  }, [text]);
+
+  // Possible modes of the component.
+  // isEditing is true:
+  // - loading is false, error is empty: Normal edit mode.
+  // - loading is false, error has a value: Normal edit mode with an error indicator.
+  // - loading is true: Save of edit is in progress; editing is disabled and a spinner
+  //   is shown. error is ignored.
+  // isEditing is false:
+  // - loading is false, error is empty: Normal display mode.
+  // - loading is false, error has a value: Normal display mode with an error indicator.
+  // - loading is true: Save of edit is in progress; going into edit mode is disabled
+  //   and a spinner is shown. error is ignored. Can't-happen case.
+
+  return isEditing ? (
+    <EditView
+      currentText={currentText}
+      setCurrentText={setCurrentText}
+      errorMessage={errorMessage}
+      loading={loading}
+      onCancel={onCancel}
+      onSave={onSave}
+    />
+  ) : (
+    <StaticView text={text} loading={loading} setEditing={setEditing} />
   );
 };
 
@@ -88,10 +187,15 @@ ClickableEdit.propTypes = {
   text: PropTypes.string.isRequired,
   setText: PropTypes.func.isRequired,
   loading: PropTypes.bool,
+  errorMessage: PropTypes.string,
 };
 
 ClickableEdit.defaultProps = {
   loading: false,
+  errorMessage: null,
 };
+
+ClickableEdit.EditView = EditView;
+ClickableEdit.StaticView = StaticView;
 
 export default ClickableEdit;

--- a/src/client/components/controls/clickable-edit.spec.js
+++ b/src/client/components/controls/clickable-edit.spec.js
@@ -11,9 +11,146 @@ describe('ClickableEdit common component', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(React, 'useEffect');
   });
 
-  it('will render the expected initial state', () => {
+  afterEach(() => {
+    React.useEffect.mockRestore();
+  });
+
+  describe('EditView', () => {
+    const defaultEditProps = {
+      currentText: 'foo',
+      setCurrentText: jest.fn(),
+      loading: false,
+      onCancel: jest.fn(),
+      onSave: jest.fn(),
+    };
+
+    it('will render the expected initial state', () => {
+      // Arrange
+      const props = defaultEditProps;
+
+      // Act
+      const wrapper = shallow(<ClickableEdit.EditView {...props} />);
+
+      // Assert
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('will render the expected validation error if edit fails', () => {
+      // Arrange
+      const props = { ...defaultEditProps, errorMessage: 'Mock error' };
+
+      // Act
+      const wrapper = shallow(<ClickableEdit.EditView {...props} />);
+
+      // Assert
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('will disable the save and cancel buttons if loading is true with edit mode on', () => {
+      // Arrange
+      const props = { ...defaultEditProps, loading: true };
+
+      // Act
+      const wrapper = shallow(<ClickableEdit.EditView {...props} />);
+
+      // Assert
+      expect(toJson(wrapper)).toMatchSnapshot();
+      const cancelButton = wrapper.find('.cancel-button');
+      expect(cancelButton.props('disabled')).toBeTruthy();
+      const saveButton = wrapper.find('.save-button');
+      expect(saveButton.length).toEqual(0);
+    });
+
+    it('will render expected text changes in edit mode', () => {
+      // Arrange
+      const props = defaultEditProps;
+      const wrapper = shallow(<ClickableEdit.EditView {...props} />);
+
+      // Act
+      wrapper.find('.textbox').simulate('change', { target: { value: 'bar' } });
+
+      // Assert
+      expect(props.setCurrentText).toHaveBeenCalledWith('bar');
+    });
+
+    it('will set text when save is clicked', () => {
+      // Arrange
+      const props = defaultEditProps;
+      const wrapper = shallow(<ClickableEdit.EditView {...props} />);
+
+      // Act
+      wrapper.find('.textbox').simulate('change', { target: { value: 'bar' } });
+      wrapper.find('.save-button').simulate('click');
+
+      // Assert
+      expect(props.onCancel).not.toHaveBeenCalled();
+      expect(props.onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('will not set text when cancel is clicked', () => {
+      // Arrange
+      const props = defaultEditProps;
+      const wrapper = shallow(<ClickableEdit.EditView {...props} />);
+
+      // Act
+      wrapper.find('.textbox').simulate('change', { target: { value: 'bar' } });
+      wrapper.find('.cancel-button').simulate('click');
+
+      // Assert
+      expect(props.onCancel).toHaveBeenCalledTimes(1);
+      expect(props.onSave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('StaticView', () => {
+    const defaultStaticProps = {
+      text: 'foo',
+      loading: false,
+      setEditing: jest.fn(),
+    };
+
+    it('will render the expected initial state', () => {
+      // Arrange
+      const props = defaultStaticProps;
+
+      // Act
+      const wrapper = shallow(<ClickableEdit.StaticView {...props} />);
+
+      // Assert
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('will hide the edit button if loading is true with edit mode off', () => {
+      // Arrange
+      const props = { ...defaultStaticProps, loading: true };
+
+      // Act
+      const wrapper = shallow(<ClickableEdit.StaticView {...props} />);
+
+      // Assert
+      expect(toJson(wrapper)).toMatchSnapshot();
+      const editButton = wrapper.find('.edit-button');
+      expect(editButton.length).toEqual(0);
+    });
+
+    it('will render the expected edit mode when edit is clicked', () => {
+      // Arrange
+      const props = defaultStaticProps;
+      const wrapper = shallow(<ClickableEdit.StaticView {...props} />);
+
+      // Act
+      wrapper.find('.edit-button').simulate('click');
+
+      // Assert
+      expect(toJson(wrapper)).toMatchSnapshot();
+      expect(props.setEditing).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('will render the static view by default', () => {
     // Arrange
     const props = defaultProps;
 
@@ -22,19 +159,6 @@ describe('ClickableEdit common component', () => {
 
     // Assert
     expect(toJson(wrapper)).toMatchSnapshot();
-  });
-
-  it('will disable the edit button if loading is true with edit mode off', () => {
-    // Arrange
-    const props = { ...defaultProps, loading: true };
-
-    // Act
-    const wrapper = shallow(<ClickableEdit {...props} />);
-
-    // Assert
-    expect(toJson(wrapper)).toMatchSnapshot();
-    const editButton = wrapper.find('.edit-button');
-    expect(editButton.props('disabled')).toBeTruthy();
   });
 
   it('will render the expected edit mode when edit is clicked', () => {
@@ -43,69 +167,189 @@ describe('ClickableEdit common component', () => {
     const wrapper = shallow(<ClickableEdit {...props} />);
 
     // Act
-    wrapper.find('.edit-button').simulate('click');
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
 
     // Assert
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('will disable the save and cancel buttons if loading is true with edit mode on', () => {
+  it('will change edit mode text when setCurrentText is called', () => {
     // Arrange
     const props = defaultProps;
     const wrapper = shallow(<ClickableEdit {...props} />);
-    wrapper.find('.edit-button').simulate('click');
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
 
     // Act
-    wrapper.setProps({ loading: true });
+    wrapper.find(ClickableEdit.EditView).prop('setCurrentText')('bar');
 
     // Assert
-    expect(toJson(wrapper)).toMatchSnapshot();
-    const cancelButton = wrapper.find('.cancel-button');
-    expect(cancelButton.props('disabled')).toBeTruthy();
-    const saveButton = wrapper.find('.save-button');
-    expect(saveButton.props('disabled')).toBeTruthy();
+    expect(wrapper.find(ClickableEdit.EditView).prop('currentText')).toEqual('bar');
   });
 
-  it('will render expected text changes in edit mode', () => {
+  it('will return to static mode when onCancel is called', () => {
     // Arrange
     const props = defaultProps;
     const wrapper = shallow(<ClickableEdit {...props} />);
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+    wrapper.find(ClickableEdit.EditView).prop('setCurrentText')('bar');
 
     // Act
-    wrapper.find('.edit-button').simulate('click');
-    wrapper.find('.textbox').simulate('change', { target: { value: 'bar' } });
+    wrapper.find(ClickableEdit.EditView).prop('onCancel')();
 
     // Assert
-    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find(ClickableEdit.StaticView).length).toEqual(1);
   });
 
-  it('will set text when save is clicked', () => {
+  it('will set currentText to original text when onCancel is called', () => {
     // Arrange
     const props = defaultProps;
     const wrapper = shallow(<ClickableEdit {...props} />);
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+    wrapper.find(ClickableEdit.EditView).prop('setCurrentText')('bar');
 
     // Act
-    wrapper.find('.edit-button').simulate('click');
-    wrapper.find('.textbox').simulate('change', { target: { value: 'bar' } });
-    wrapper.find('.save-button').simulate('click');
+    wrapper.find(ClickableEdit.EditView).prop('onCancel')();
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
 
     // Assert
-    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find(ClickableEdit.EditView).prop('currentText')).toEqual('foo');
+  });
+
+  it('will attempt to set text to currentText when onSave is called', () => {
+    // Arrange
+    const props = defaultProps;
+    const wrapper = shallow(<ClickableEdit {...props} />);
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+    wrapper.find(ClickableEdit.EditView).prop('setCurrentText')('bar');
+
+    // Act
+    wrapper.find(ClickableEdit.EditView).prop('onSave')();
+
+    // Assert
+    expect(props.setText).toHaveBeenCalledTimes(1);
     expect(props.setText).toHaveBeenCalledWith('bar');
   });
 
-  it('will not set text when cancel is clicked', () => {
+  it('will return to static mode when onSave is called if setText returns false', () => {
     // Arrange
     const props = defaultProps;
+    props.setText.mockReturnValue(false);
     const wrapper = shallow(<ClickableEdit {...props} />);
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+    wrapper.find(ClickableEdit.EditView).prop('setCurrentText')('bar');
 
     // Act
-    wrapper.find('.edit-button').simulate('click');
-    wrapper.find('.textbox').simulate('change', { target: { value: 'bar' } });
-    wrapper.find('.cancel-button').simulate('click');
+    wrapper.find(ClickableEdit.EditView).prop('onSave')();
 
     // Assert
-    expect(toJson(wrapper)).toMatchSnapshot();
-    expect(props.setText).not.toHaveBeenCalled();
+    expect(wrapper.find(ClickableEdit.StaticView).length).toEqual(1);
+  });
+
+  it('will stay in edit mode when onSave is called if setText returns false', () => {
+    // Arrange
+    const props = defaultProps;
+    props.setText.mockReturnValue(true);
+    const wrapper = shallow(<ClickableEdit {...props} />);
+    wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+    wrapper.find(ClickableEdit.EditView).prop('setCurrentText')('bar');
+
+    // Act
+    wrapper.find(ClickableEdit.EditView).prop('onSave')();
+
+    // Assert
+    expect(wrapper.find(ClickableEdit.EditView).length).toEqual(1);
+  });
+
+  describe('useEffect', () => {
+    const NUMBER_OF_USE_EFFECT_CALLS = 2;
+
+    it('will set up two effects on render', () => {
+      // Arrange
+      const props = defaultProps;
+
+      // Act
+      shallow(<ClickableEdit {...props} />);
+
+      // Assert
+      expect(React.useEffect).toHaveBeenCalledTimes(NUMBER_OF_USE_EFFECT_CALLS);
+      expect(React.useEffect).toHaveBeenCalledWith(expect.any(Function), [false, null]);
+      expect(React.useEffect).toHaveBeenCalledWith(expect.any(Function), ['foo']);
+    });
+
+    describe('onLoadingChanged', () => {
+      const USE_EFFECT_INDEX = 0;
+
+      it('will stay in edit mode when loading goes from false to true', () => {
+        // Arrange
+        const props = defaultProps;
+        const wrapper = shallow(<ClickableEdit {...props} />);
+        wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+
+        // Act
+        wrapper.setProps({ loading: true });
+        const [onLoadingChanged] = React.useEffect.mock.calls[
+          NUMBER_OF_USE_EFFECT_CALLS * 2 + USE_EFFECT_INDEX
+        ];
+        onLoadingChanged();
+
+        // Assert
+        expect(wrapper.find(ClickableEdit.EditView).length).toEqual(1);
+      });
+
+      it('will return to static mode when loading goes from true to false and there is no error message', () => {
+        // Arrange
+        const props = { ...defaultProps, loading: true };
+        const wrapper = shallow(<ClickableEdit {...props} />);
+        wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+
+        // Act
+        wrapper.setProps({ loading: false });
+        const [onLoadingChanged] = React.useEffect.mock.calls[
+          NUMBER_OF_USE_EFFECT_CALLS * 2 + USE_EFFECT_INDEX
+        ];
+        onLoadingChanged();
+
+        // Assert
+        expect(wrapper.find(ClickableEdit.StaticView).length).toEqual(1);
+      });
+
+      it('will stay in edit mode when loading goes from true to false and there is an error message', () => {
+        // Arrange
+        const props = { ...defaultProps, loading: true };
+        const wrapper = shallow(<ClickableEdit {...props} />);
+        wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+
+        // Act
+        wrapper.setProps({ loading: false, errorMessage: 'Mock error' });
+        const [onLoadingChanged] = React.useEffect.mock.calls[
+          NUMBER_OF_USE_EFFECT_CALLS * 2 + USE_EFFECT_INDEX
+        ];
+        onLoadingChanged();
+
+        // Assert
+        expect(wrapper.find(ClickableEdit.EditView).length).toEqual(1);
+      });
+    });
+
+    describe('onTextChanged', () => {
+      const USE_EFFECT_INDEX = 1;
+
+      it('will update edit mode text when normal text changes', () => {
+        // Arrange
+        const props = defaultProps;
+        const wrapper = shallow(<ClickableEdit {...props} />);
+
+        // Act
+        wrapper.setProps({ text: 'bar' });
+        const [onTextChanged] = React.useEffect.mock.calls[
+          NUMBER_OF_USE_EFFECT_CALLS * 1 + USE_EFFECT_INDEX
+        ];
+        onTextChanged();
+        wrapper.find(ClickableEdit.StaticView).prop('setEditing')(true);
+
+        // Assert
+        expect(wrapper.find(ClickableEdit.EditView).prop('currentText')).toEqual('bar');
+      });
+    });
   });
 });

--- a/src/client/store/api/api.action-creator.js
+++ b/src/client/store/api/api.action-creator.js
@@ -88,11 +88,14 @@ export function createApiAction(type, payloadCreator, metaCreator) {
         onResponse(dispatch, getState, response);
       }
     } catch (error) {
+      // TODO: Uncomment the bits to get the server error message into the state?
+      // const { response: { data: errorResponseData } = {} } = error;
       dispatch({
         type: `${type}.ERROR`,
         payload: {
           ...payload,
           error,
+          // error: errorResponseData || error,
         },
         meta,
         error: true,


### PR DESCRIPTION
Modifies ClickableEdit component to allow async editing:
* The return value of setText is now checked. If setText returns true, the control should stay in edit mode either becaue the edit is async or because there was a validation error.
* The errorMessage prop will display a validation error when set.

To use ClickableEdit in async mode, the parent component should provide the following props:
* A setText prop that triggers the async request always returns true.
* A loading prop that will be true if the async request is in progress.
* An errorMessage prop that will have an appropriate message if the async request fails.

To use ClickableEdit in sync mode, the parent component should provide the following props:
* A setText prop that returns true if the edit fails.
* A loading prop that is always false.
* An errorMessage prop that will have an appropriate message if the edit fails.

Also modifies the following components:
* NewCharacter now sets an error message if the user tries to set a blank name.
* Character's name edit now supplies an error message from the API response if the edit request fails.